### PR TITLE
a typo fixed by Tianyun

### DIFF
--- a/R/allele_qc.R
+++ b/R/allele_qc.R
@@ -154,7 +154,7 @@ allele_qc <- function(target_data, ref_variants, col_to_flip = NULL,
     dups <- vec_duplicate_detect(result[, c("chrom", "pos", "variants_id_qced")])
     if (any(dups)) {
       result <- result[!dups, , drop = FALSE]
-      Warning("Unexpected duplicates were removed.")
+      warning("Unexpected duplicates were removed.")
     }
   }
     


### PR DESCRIPTION
this misspelling of Warning() wil cause error when removing duplicates in rss_analysis.ipynb.