### PR TITLE
RSS fine-mapping defaults: make L/lGreedy/minAbsCorr/rFinite/rMismatch optional

### DIFF
--- a/R/susie_wrapper.R
+++ b/R/susie_wrapper.R
@@ -257,6 +257,7 @@ postprocessFinemappingFits <- function(fits, dataX, dataY = NULL,
                                        region = NULL,
                                        priorEffTol = 1e-9,
                                        minAbsCorr = 0.8,
+                                       medianAbsCorr = NULL,
                                        csInput = NULL) {
   fits <- fits[!vapply(fits, is.null, logical(1))]
   if (length(fits) == 0) stop("At least one fine-mapping fit must be supplied.")
@@ -276,6 +277,7 @@ postprocessFinemappingFits <- function(fits, dataX, dataY = NULL,
       signalCutoff = signalCutoff, otherQuantities = otherQuantities,
       region = region,
       priorEffTol = priorEffTol, minAbsCorr = minAbsCorr,
+      medianAbsCorr = medianAbsCorr,
       csInput = csInput
     )
   })
@@ -343,6 +345,7 @@ postprocessFinemappingFit.susiF <- function(fit, method = "fsusie", csInput = NU
                                              region = NULL,
                                              priorEffTol = 1e-9,
                                              minAbsCorr = 0.8,
+                                             medianAbsCorr = NULL,
                                              csInput = c("X", "Xcorr", "fsusie")) {
   csInput <- match.arg(csInput)
   variantNames <- extractVariantNames(fit)
@@ -351,7 +354,7 @@ postprocessFinemappingFit.susiF <- function(fit, method = "fsusie", csInput = NU
   csTables <- computeCsTables(
     fit, dataX = dataX, coverage = coverage,
     secondaryCoverage = secondaryCoverage, method = method,
-    csInput = csInput, minAbsCorr = minAbsCorr
+    csInput = csInput, minAbsCorr = minAbsCorr, medianAbsCorr = medianAbsCorr
   )
   topLoci <- buildTopLoci(
     fit, csTables, variantNames = variantNames, sumstats = sumstats,
@@ -451,7 +454,7 @@ selectEffects <- function(fit, priorEffTol = 1e-9) {
 computeCsTables <- function(fit, dataX, coverage = NULL,
                             secondaryCoverage = c(0.7, 0.5),
                             method = "susie", csInput = c("X", "Xcorr", "fsusie"),
-                            minAbsCorr = 0.8) {
+                            minAbsCorr = 0.8, medianAbsCorr = NULL) {
   csInput <- match.arg(csInput)
   primaryCoverage <- coverage
   if (is.null(primaryCoverage)) primaryCoverage <- fit$sets$requested_coverage
@@ -460,7 +463,8 @@ computeCsTables <- function(fit, dataX, coverage = NULL,
   coverages <- coverages[!is.na(coverages)]
 
   tables <- lapply(coverages, function(cov) {
-    computeCsTable(fit, dataX, coverage = cov, csInput = csInput, minAbsCorr = minAbsCorr)
+    computeCsTable(fit, dataX, coverage = cov, csInput = csInput,
+                   minAbsCorr = minAbsCorr, medianAbsCorr = medianAbsCorr)
   })
   names(tables) <- vapply(coverages, formatCsColumn, character(1), method = method)
   attr(tables, "coverage") <- coverages
@@ -468,7 +472,7 @@ computeCsTables <- function(fit, dataX, coverage = NULL,
 }
 
 computeCsTable <- function(fit, dataX, coverage, csInput = c("X", "Xcorr", "fsusie"),
-                           minAbsCorr = 0.8) {
+                           minAbsCorr = 0.8, medianAbsCorr = NULL) {
   csInput <- match.arg(csInput)
   if (csInput == "fsusie") {
     sets <- tryCatch(
@@ -489,12 +493,18 @@ computeCsTable <- function(fit, dataX, coverage, csInput = c("X", "Xcorr", "fsus
     return(list(sets = sets, cs_corr = csCorr, pip = fit$pip))
   }
 
+  # Purity thresholds for credible-set extraction. min_abs_corr / median_abs_corr
+  # are isolated from finemappingOpts upstream and routed here; pass each only
+  # when set. `fit` is passed positionally as `res`.
+  csArgs <- list(coverage = coverage)
+  if (!is.null(minAbsCorr)) csArgs$min_abs_corr <- minAbsCorr
+  if (!is.null(medianAbsCorr)) csArgs$median_abs_corr <- medianAbsCorr
   if (csInput == "X") {
-    sets <- susie_get_cs(fit, X = dataX, coverage = coverage, min_abs_corr = minAbsCorr)
+    sets <- do.call(susie_get_cs, c(list(fit), csArgs, list(X = dataX)))
     out <- list(sets = sets, pip = fit$pip)
     out$cs_corr <- get_cs_correlation(out, X = dataX)
   } else {
-    sets <- susie_get_cs(fit, Xcorr = dataX, coverage = coverage, min_abs_corr = minAbsCorr)
+    sets <- do.call(susie_get_cs, c(list(fit), csArgs, list(Xcorr = dataX)))
     out <- list(sets = sets, pip = fit$pip)
     out$cs_corr <- get_cs_correlation(out, Xcorr = dataX)
   }
@@ -937,8 +947,13 @@ adjustSusieWeights <- function(twasWeightsResults, keepVariants, runAlleleQc = T
 #' @param ldMat LD correlation matrix. Mutually exclusive with xMat.
 #' @param xMat Genotype matrix (samples x variants). Mutually exclusive with ldMat.
 #' @param n Sample size.
-#' @param L Maximum number of causal configurations (default: 30).
-#' @param lGreedy Initial greedy number of causal configurations (default: 5).
+#' @param finemappingOpts Free-form list of fine-mapping options forwarded as-is
+#'   into \code{susieR::susie_rss()} (e.g. \code{L}, \code{L_greedy},
+#'   \code{R_finite}, \code{R_mismatch}). A key supplied is passed through; a key
+#'   omitted inherits \code{susie_rss}'s own default. Two purity keys are special:
+#'   \code{min_abs_corr} (default \code{0.8}) and \code{median_abs_corr} (default
+#'   \code{NULL}) are isolated from this list and routed to
+#'   \code{susieR::susie_get_cs()} for credible-set extraction, not the fit.
 #' @param analysisMethod Iteration mode for the \code{"susieRss"} fit:
 #'   \code{"susieRss"} (default, normal IBSS), \code{"singleEffect"} (L=1,
 #'   single iteration), or \code{"bayesianConditionalRegression"}
@@ -960,13 +975,7 @@ adjustSusieWeights <- function(twasWeightsResults, keepVariants, runAlleleQc = T
 #' @param coverage Coverage level (default: 0.95).
 #' @param secondaryCoverage Secondary coverage levels (default: c(0.7, 0.5)).
 #' @param signalCutoff PIP cutoff for selecting top loci (default: 0.1).
-#' @param minAbsCorr Minimum absolute correlation for CS purity (default: 0.8).
-#' @param rFinite Controls variance inflation to account for estimating
-#'   the R matrix from a finite reference panel. NULL (default): no
-#'   variance inflation. Passed directly to susieRss.
-#' @param rMismatch LD mismatch correction method passed directly to susieRss.
-#'   Default NULL disables mismatch correction.
-#' @param ... Additional parameters passed to susieRss. Supplying
+#' @param ... Additional parameters passed to susie_rss. Supplying
 #'   \code{var_y} here, together with \code{beta} and \code{se} columns in
 #'   \code{sumstats}, selects the \code{bhat/shat/var_y} sufficient-statistic
 #'   interface. Without \code{var_y}, this wrapper uses the z-score RSS
@@ -981,19 +990,24 @@ adjustSusieWeights <- function(twasWeightsResults, keepVariants, runAlleleQc = T
 #' @importFrom dplyr arrange select
 #' @export
 susieRssPipeline <- function(sumstats, ldMat = NULL, xMat = NULL, n = NULL,
-                             L = 30, lGreedy = 5,
                              analysisMethod = c("susieRss", "singleEffect", "bayesianConditionalRegression"),
                              methods = NULL,
                              addSusieInf = TRUE,
                              coverage = 0.95,
                              secondaryCoverage = c(0.7, 0.5),
                              signalCutoff = 0.1,
-                             minAbsCorr = 0.8,
-                             rFinite = NULL, rMismatch = NULL, ...) {
+                             finemappingOpts = list(), ...) {
   analysisMethod <- match.arg(analysisMethod)
   if (is.null(ldMat) && is.null(xMat)) stop("Either ldMat or xMat must be provided.")
   if (!is.null(ldMat) && !is.null(xMat)) stop("Only one of ldMat or xMat should be provided, not both.")
-  if (!is.null(lGreedy)) lGreedy <- min(lGreedy, L)
+  # Fine-mapping options are a free-form passthrough to susie_rss. Isolate the
+  # two credible-set purity options (they act at susie_get_cs extraction, not the
+  # fit) and route them separately; everything else flows into the susie_rss call.
+  if (!is.list(finemappingOpts)) stop("finemappingOpts must be a list.")
+  minAbsCorr <- finemappingOpts$min_abs_corr %||% 0.8
+  medianAbsCorr <- finemappingOpts$median_abs_corr   # NULL when absent (susie_get_cs default)
+  finemappingOpts$min_abs_corr <- NULL
+  finemappingOpts$median_abs_corr <- NULL
 
   # Resolve effective methods. NULL => legacy single-method via analysisMethod.
   validRssMethods <- c("susieRss", "susieInfRss", "susieAshRss")
@@ -1031,10 +1045,12 @@ susieRssPipeline <- function(sumstats, ldMat = NULL, xMat = NULL, n = NULL,
     names(z) <- rownames(sumstats)
   }
 
-  dots <- list(...)
-  varY <- dots$varY
-  dots$varY <- NULL
-  if (!is.null(dots$bhat) || !is.null(dots$shat)) {
+  # Free-form passthrough to susie_rss: finemappingOpts (purity keys already
+  # isolated above) plus any extra named args. Forwarded verbatim into the fit.
+  fitOpts <- c(finemappingOpts, list(...))
+  varY <- fitOpts$varY
+  fitOpts$varY <- NULL
+  if (!is.null(fitOpts$bhat) || !is.null(fitOpts$shat)) {
     stop("Pass summary effects as 'beta' and 'se' columns in sumstats; ",
          "susieRssPipeline constructs bhat and shat internally.")
   }
@@ -1058,33 +1074,34 @@ susieRssPipeline <- function(sumstats, ldMat = NULL, xMat = NULL, n = NULL,
     shat <- sumstats$se
     names(bhat) <- names(shat) <- names(z)
     common <- c(list(bhat = bhat, shat = shat, var_y = varY, n = n,
-                     coverage = coverage, R_finite = rFinite,
-                     R_mismatch = rMismatch), dots)
+                     coverage = coverage), fitOpts)
   } else {
-    common <- c(list(z = z, n = n, coverage = coverage,
-                     R_finite = rFinite, R_mismatch = rMismatch), dots)
+    common <- c(list(z = z, n = n, coverage = coverage), fitOpts)
   }
   if (!is.null(xMat)) common$X <- xMat else common$R <- ldMat
 
+  # Method-specific overrides are applied with modifyList so they win over any
+  # passthrough key of the same name (e.g. single_effect forces L = 1) without a
+  # duplicate-argument error.
   fitOneSusieRss <- function() {
     if (analysisMethod == "singleEffect") {
-      do.call(susie_rss, c(common, list(L = 1, L_greedy = NULL, max_iter = 1)))
+      do.call(susie_rss, modifyList(common, list(L = 1, L_greedy = NULL, max_iter = 1)))
     } else if (analysisMethod == "bayesianConditionalRegression") {
-      do.call(susie_rss, c(common, list(L = L, L_greedy = lGreedy, max_iter = 1)))
+      do.call(susie_rss, modifyList(common, list(max_iter = 1)))
     } else {
-      do.call(susie_rss, c(common, list(L = L, L_greedy = lGreedy)))
+      do.call(susie_rss, common)
     }
   }
   fitOneSusieInfRss <- function() {
-    do.call(susie_rss, c(common, list(L = L, L_greedy = lGreedy,
-                                       unmappable_effects = "inf",
-                                       convergence_method = "pip",
-                                       refine = FALSE, model_init = NULL)))
+    do.call(susie_rss, modifyList(common,
+                         list(unmappable_effects = "inf",
+                              convergence_method = "pip",
+                              refine = FALSE, model_init = NULL)))
   }
   fitOneSusieAshRss <- function() {
-    do.call(susie_rss, c(common, list(L = L, L_greedy = lGreedy,
-                                       unmappable_effects = "ash",
-                                       convergence_method = "pip")))
+    do.call(susie_rss, modifyList(common,
+                         list(unmappable_effects = "ash",
+                              convergence_method = "pip")))
   }
 
   fittedModels <- list()
@@ -1097,11 +1114,11 @@ susieRssPipeline <- function(sumstats, ldMat = NULL, xMat = NULL, n = NULL,
       identical(fitMethods, "bayesianConditionalRegression")) {
     if (chainInfToSusieRss) {
       chainedArgs <- prepareSusieFromInfArgs(
-        list(L = L, L_greedy = lGreedy),
+        list(L = common$L, L_greedy = common$L_greedy),
         fittedModels[["susieInfRss"]], refineDefault = TRUE,
         unmappableEffects = "none"
       )
-      rssFit <- do.call(susie_rss, c(common, chainedArgs))
+      rssFit <- do.call(susie_rss, modifyList(common, chainedArgs))
     } else {
       rssFit <- fitOneSusieRss()
     }
@@ -1112,11 +1129,11 @@ susieRssPipeline <- function(sumstats, ldMat = NULL, xMat = NULL, n = NULL,
   if ("susieAshRss" %in% fitMethods) {
     if (chainInfToSusieAshRss) {
       chainedArgs <- prepareSusieFromInfArgs(
-        list(L = L, L_greedy = lGreedy),
+        list(L = common$L, L_greedy = common$L_greedy),
         fittedModels[["susieInfRss"]], refineDefault = NULL,
         unmappableEffects = "ash"
       )
-      ashFit <- do.call(susie_rss, c(common, chainedArgs))
+      ashFit <- do.call(susie_rss, modifyList(common, chainedArgs))
     } else {
       ashFit <- fitOneSusieAshRss()
     }
@@ -1154,6 +1171,7 @@ susieRssPipeline <- function(sumstats, ldMat = NULL, xMat = NULL, n = NULL,
     secondaryCoverage = secondaryCoverage,
     signalCutoff = signalCutoff,
     minAbsCorr = minAbsCorr,
+    medianAbsCorr = medianAbsCorr,
     csInput = ppCsInput
   )
   # Primary method preference: "susieRss" > other names > first fit

--- a/R/univariate_pipeline.R
+++ b/R/univariate_pipeline.R
@@ -519,15 +519,17 @@ regionDataToSusieRssInput <- function(rssInput, ldData) {
 #' @param addSusieInf Logical controlling chained init when
 #'   \code{"susieInfRss"} is in \code{methods} alongside
 #'   \code{"susieRss"} and/or \code{"susieAshRss"}. Default \code{TRUE}.
-#' @param finemappingOpts List of fine-mapping options (L, lGreedy, coverage,
-#'   signalCutoff, minAbsCorr).
+#' @param finemappingOpts Free-form list of fine-mapping options. \code{coverage}
+#'   and \code{signal_cutoff} are pipeline-reporting choices kept here; everything
+#'   else (e.g. \code{L}, \code{L_greedy}, \code{R_finite}, \code{R_mismatch}) is
+#'   forwarded as-is into \code{susieR::susie_rss()} — supplied keys pass through,
+#'   omitted keys inherit susieR defaults (a run with the fit params unset matches
+#'   a manual \code{susie_rss()} call). The purity keys \code{min_abs_corr}
+#'   (default \code{0.8}) and \code{median_abs_corr} (default \code{NULL}) are
+#'   isolated and routed to \code{susieR::susie_get_cs()} instead of the fit.
 #' @param impute Whether to impute missing variants via RAISS (default TRUE).
 #' @param imputeOpts List of imputation options (rcond, R2_threshold, minimum_ld, lamb).
 #' @param pipCutoffToSkip PIP threshold for early stopping (default 0, no skip).
-#' @param rFinite Controls variance inflation to account for finite reference LD.
-#'   Passed to \code{susieR::susie_rss()}.
-#' @param rMismatch LD mismatch correction method passed to \code{susieR::susie_rss()}.
-#'   Default NULL disables mismatch correction.
 #' @param keepIndel Whether to keep indel variants (default TRUE).
 #' @param commentString Comment character for sumstat file (default "#").
 #' @param diagnostics Whether to include diagnostic info (default FALSE).
@@ -547,18 +549,21 @@ rssAnalysisPipeline <- function(
     methods = NULL,
     addSusieInf = TRUE,
     finemappingOpts = list(
-      L = 20, lGreedy = 5,
-      coverage = c(0.95, 0.7, 0.5), signalCutoff = 0.025,
-      minAbsCorr = 0.8
+      L = 20, L_greedy = 5,
+      coverage = c(0.95, 0.7, 0.5), signal_cutoff = 0.025
     ),
     impute = TRUE, imputeOpts = list(rcond = 0.01, r2Threshold = 0.6, minimumLd = 5, lamb = 0.01),
-    pipCutoffToSkip = 0, rFinite = NULL, rMismatch = NULL,
+    pipCutoffToSkip = 0,
     keepIndel = TRUE, commentString = "#", diagnostics = FALSE,
     binaryTraitModel = c("rss", "ols")) {
   binaryTraitModel <- match.arg(binaryTraitModel)
   if (!is(ldData, "LdData")) {
     stop("ldData must be an LdData object")
   }
+  # R_finite / R_mismatch are susie_rss fit options supplied via finemappingOpts;
+  # source them once here for the QC stage (which also accepts them).
+  rFinite <- finemappingOpts$R_finite %||% finemappingOpts$rFinite
+  rMismatch <- finemappingOpts$R_mismatch %||% finemappingOpts$rMismatch
   res <- list()
   rssInput <- loadRssData(
     sumstatPath = sumstatPath, columnFilePath = columnFilePath,
@@ -648,20 +653,22 @@ rssAnalysisPipeline <- function(
     priCoverage <- finemappingOpts$coverage[1]
     secCoverage <- if (length(finemappingOpts$coverage) > 1) finemappingOpts$coverage[-1] else NULL
 
-    finemappingOptsLGreedy <- finemappingOpts$lGreedy
-    finemappingOptsSignalCutoff <- finemappingOpts$signalCutoff
-    finemappingOptsMinAbsCorr <- finemappingOpts$minAbsCorr
+    finemappingOptsSignalCutoff <- finemappingOpts$signal_cutoff %||% finemappingOpts$signalCutoff %||% 0.025
+    # The fit/purity passthrough = finemappingOpts minus the pipeline-reporting keys
+    # (coverage / signal_cutoff), which susieRssPipeline takes as separate arguments.
+    # susieRssPipeline isolates min_abs_corr/median_abs_corr and forwards the rest to susie_rss.
+    finemappingOptsForFit <- finemappingOpts
+    finemappingOptsForFit$coverage <- NULL
+    finemappingOptsForFit$signal_cutoff <- NULL
+    finemappingOptsForFit$signalCutoff <- NULL
     res <- do.call(susieRssPipeline, c(susieReady, list(
-      L = finemappingOpts$L, lGreedy = finemappingOptsLGreedy,
       analysisMethod = finemappingMethod,
       methods = methods,
       addSusieInf = addSusieInf,
       coverage = priCoverage,
       secondaryCoverage = secCoverage,
       signalCutoff = finemappingOptsSignalCutoff,
-      minAbsCorr = finemappingOptsMinAbsCorr,
-      rFinite = rFinite,
-      rMismatch = rMismatch
+      finemappingOpts = finemappingOptsForFit
     )))
     if (!identical(zMismatchQc, "none") || isTRUE(alleleFlipKriging)) {
       res$outlierNumber <- qcResults$outlierNumber
@@ -686,15 +693,14 @@ rssAnalysisPipeline <- function(
       list(sumstats = sumstats, n = n, varY = varY),
       ldData
     )$susieRssInput
+    fmFit <- finemappingOpts
+    fmFit$coverage <- NULL; fmFit$signal_cutoff <- NULL; fmFit$signalCutoff <- NULL
     do.call(susieRssPipeline, c(reanalysisInput, list(
-      L = finemappingOpts$L, lGreedy = finemappingOpts$lGreedy,
       analysisMethod = method,
       coverage = priCoverage,
       secondaryCoverage = secCoverage,
       signalCutoff = finemappingOptsSignalCutoff,
-      minAbsCorr = finemappingOptsMinAbsCorr,
-      rFinite = rFinite,
-      rMismatch = rMismatch
+      finemappingOpts = fmFit
     )))
   }
 
@@ -712,7 +718,7 @@ rssAnalysisPipeline <- function(
             csNamesBvsr <- names(bvsrRes$sets$cs)
             blockCsMetrics <- extractCsInfo(conData = res, csNames = csNamesBvsr, topLociTable = res$top_loci)
         } else { # no CS
-            if (sum(bvsrRes$pip > finemappingOpts$signalCutoff) > 0) {
+            if (sum(bvsrRes$pip > finemappingOptsSignalCutoff) > 0) {
                 blockCsMetrics <- extractTopPipInfo(res)
             }
         }

--- a/man/postprocessFinemappingFits.Rd
+++ b/man/postprocessFinemappingFits.Rd
@@ -18,6 +18,7 @@ postprocessFinemappingFits(
   region = NULL,
   priorEffTol = 1e-09,
   minAbsCorr = 0.8,
+  medianAbsCorr = NULL,
   csInput = NULL
 )
 }

--- a/man/rssAnalysisPipeline.Rd
+++ b/man/rssAnalysisPipeline.Rd
@@ -21,13 +21,11 @@ rssAnalysisPipeline(
   finemappingMethod = c("susieRss", "singleEffect", "bayesianConditionalRegression"),
   methods = NULL,
   addSusieInf = TRUE,
-  finemappingOpts = list(L = 20, lGreedy = 5, coverage = c(0.95, 0.7, 0.5), signalCutoff
-    = 0.025, minAbsCorr = 0.8),
+  finemappingOpts = list(L = 20, L_greedy = 5, coverage = c(0.95, 0.7, 0.5),
+    signal_cutoff = 0.025),
   impute = TRUE,
   imputeOpts = list(rcond = 0.01, r2Threshold = 0.6, minimumLd = 5, lamb = 0.01),
   pipCutoffToSkip = 0,
-  rFinite = NULL,
-  rMismatch = NULL,
   keepIndel = TRUE,
   commentString = "#",
   diagnostics = FALSE,
@@ -93,20 +91,20 @@ SuSiE-inf-RSS fit initialises the chained downstream method(s).}
 \code{"susieInfRss"} is in \code{methods} alongside
 \code{"susieRss"} and/or \code{"susieAshRss"}. Default \code{TRUE}.}
 
-\item{finemappingOpts}{List of fine-mapping options (L, lGreedy, coverage,
-signalCutoff, minAbsCorr).}
+\item{finemappingOpts}{Free-form list of fine-mapping options. \code{coverage}
+and \code{signal_cutoff} are pipeline-reporting choices kept here; everything
+else (e.g. \code{L}, \code{L_greedy}, \code{R_finite}, \code{R_mismatch}) is
+forwarded as-is into \code{susieR::susie_rss()} — supplied keys pass through,
+omitted keys inherit susieR defaults (a run with the fit params unset matches
+a manual \code{susie_rss()} call). The purity keys \code{min_abs_corr}
+(default \code{0.8}) and \code{median_abs_corr} (default \code{NULL}) are
+isolated and routed to \code{susieR::susie_get_cs()} instead of the fit.}
 
 \item{impute}{Whether to impute missing variants via RAISS (default TRUE).}
 
 \item{imputeOpts}{List of imputation options (rcond, R2_threshold, minimum_ld, lamb).}
 
 \item{pipCutoffToSkip}{PIP threshold for early stopping (default 0, no skip).}
-
-\item{rFinite}{Controls variance inflation to account for finite reference LD.
-Passed to \code{susieR::susie_rss()}.}
-
-\item{rMismatch}{LD mismatch correction method passed to \code{susieR::susie_rss()}.
-Default NULL disables mismatch correction.}
 
 \item{keepIndel}{Whether to keep indel variants (default TRUE).}
 

--- a/man/susieRssPipeline.Rd
+++ b/man/susieRssPipeline.Rd
@@ -9,17 +9,13 @@ susieRssPipeline(
   ldMat = NULL,
   xMat = NULL,
   n = NULL,
-  L = 30,
-  lGreedy = 5,
   analysisMethod = c("susieRss", "singleEffect", "bayesianConditionalRegression"),
   methods = NULL,
   addSusieInf = TRUE,
   coverage = 0.95,
   secondaryCoverage = c(0.7, 0.5),
   signalCutoff = 0.1,
-  minAbsCorr = 0.8,
-  rFinite = NULL,
-  rMismatch = NULL,
+  finemappingOpts = list(),
   ...
 )
 }
@@ -31,10 +27,6 @@ susieRssPipeline(
 \item{xMat}{Genotype matrix (samples x variants). Mutually exclusive with ldMat.}
 
 \item{n}{Sample size.}
-
-\item{L}{Maximum number of causal configurations (default: 30).}
-
-\item{lGreedy}{Initial greedy number of causal configurations (default: 5).}
 
 \item{analysisMethod}{Iteration mode for the \code{"susieRss"} fit:
 \code{"susieRss"} (default, normal IBSS), \code{"singleEffect"} (L=1,
@@ -63,16 +55,15 @@ the downstream method(s) as initialisation. Default \code{TRUE}.}
 
 \item{signalCutoff}{PIP cutoff for selecting top loci (default: 0.1).}
 
-\item{minAbsCorr}{Minimum absolute correlation for CS purity (default: 0.8).}
+\item{finemappingOpts}{Free-form list of fine-mapping options forwarded as-is
+into \code{susieR::susie_rss()} (e.g. \code{L}, \code{L_greedy},
+\code{R_finite}, \code{R_mismatch}). A key supplied is passed through; a key
+omitted inherits \code{susie_rss}'s own default. Two purity keys are special:
+\code{min_abs_corr} (default \code{0.8}) and \code{median_abs_corr} (default
+\code{NULL}) are isolated from this list and routed to
+\code{susieR::susie_get_cs()} for credible-set extraction, not the fit.}
 
-\item{rFinite}{Controls variance inflation to account for estimating
-the R matrix from a finite reference panel. NULL (default): no
-variance inflation. Passed directly to susieRss.}
-
-\item{rMismatch}{LD mismatch correction method passed directly to susieRss.
-Default NULL disables mismatch correction.}
-
-\item{...}{Additional parameters passed to susieRss. Supplying
+\item{...}{Additional parameters passed to susie_rss. Supplying
 \code{var_y} here, together with \code{beta} and \code{se} columns in
 \code{sumstats}, selects the \code{bhat/shat/var_y} sufficient-statistic
 interface. Without \code{var_y}, this wrapper uses the z-score RSS

--- a/tests/testthat/test_susie_wrapper.R
+++ b/tests/testthat/test_susie_wrapper.R
@@ -290,7 +290,7 @@ test_that("susieRssPipeline runs with bayesianConditionalRegression", {
 
   result <- susieRssPipeline(sumstats, R,
     analysisMethod = "bayesianConditionalRegression",
-    L = 5, lGreedy = 5
+    finemappingOpts = list(L = 5, L_greedy = 5)
   )
   expect_true(is.list(result))
   expect_true("finemappingResult" %in% names(result))
@@ -327,7 +327,7 @@ test_that("susieRssPipeline uses beta/se when z not provided", {
 
   result <- susieRssPipeline(sumstats, R,
     analysisMethod = "susieRss",
-    L = 5, lGreedy = 5
+    finemappingOpts = list(L = 5, L_greedy = 5)
   )
   expect_true(is.list(result))
   expect_true("finemappingResult" %in% names(result))
@@ -687,9 +687,9 @@ test_that("susieRssPipeline X-mode passes X to susieRss and computes LD from X f
     },
     formatFinemappingOutput = function(post, primaryMethod) list()
   )
-  result <- susieRssPipeline(list(z = z), xMat = X, rMismatch = "eb")
+  result <- susieRssPipeline(list(z = z), xMat = X, finemappingOpts = list(R_mismatch = "eb"))
   expect_true("X" %in% names(captured_susie_args))
-  expect_null(captured_susie_args$R)
+  expect_null(captured_susie_args[["R"]])   # exact match: $R would partial-match R_mismatch
   expect_equal(captured_susie_args$R_mismatch, "eb")
   # Post-processor receives raw X matrix (n x p), not cor(X)
   expect_equal(dim(captured_pp_data_x), c(n, p))
@@ -1301,4 +1301,88 @@ test_that("posterior_effect_mean equals colSums(alpha*mu); posterior_effect_se e
     expect_equal(unique(row$posterior_effect_se), expected_se[i],
                  tolerance = 1e-10)
   }
+})
+
+# ===========================================================================
+# rss-finemap-defaults: finemappingOpts passthrough + isolated purity (Step 3)
+# ===========================================================================
+
+.fm_fake_fit <- function(p, vnames) list(
+  pip = setNames(rep(0.01, p), vnames),
+  alpha = matrix(1 / p, nrow = 5, ncol = p),
+  lbf_variable = matrix(0, nrow = 5, ncol = p),
+  V = rep(1, 5), sets = list(cs = NULL, requestedCoverage = 0.95), niter = 10
+)
+
+test_that("finemappingOpts entries are forwarded as-is into susie_rss; empty forwards none", {
+  skip_if_not_installed("susieR")
+  p <- 5; z <- rnorm(p); vnames <- paste0("chr1:", 1:p, ":A:G"); names(z) <- vnames
+  R <- diag(p); rownames(R) <- colnames(R) <- vnames
+  cap <- NULL
+  local_mocked_bindings(
+    susie_rss = function(...) { cap <<- list(...); .fm_fake_fit(p, vnames) },
+    susie_get_cs = function(...) list(cs = NULL, requested_coverage = 0.95),
+    get_cs_correlation = function(...) NULL
+  )
+  susieRssPipeline(list(z = z, variant_id = vnames), ldMat = R,
+                   finemappingOpts = list(L = 7, R_mismatch = "eb"))
+  expect_equal(cap[["L"]], 7)
+  expect_equal(cap[["R_mismatch"]], "eb")
+  # empty finemappingOpts forwards no fit params (susie_rss defaults apply)
+  cap <- NULL
+  susieRssPipeline(list(z = z, variant_id = vnames), ldMat = R, finemappingOpts = list())
+  expect_false("L" %in% names(cap))
+  expect_false("R_finite" %in% names(cap))
+  expect_false("R_mismatch" %in% names(cap))
+})
+
+test_that("min_abs_corr / median_abs_corr are isolated to susie_get_cs, not susie_rss", {
+  skip_if_not_installed("susieR")
+  p <- 5; z <- rnorm(p); vnames <- paste0("chr1:", 1:p, ":A:G"); names(z) <- vnames
+  R <- diag(p); rownames(R) <- colnames(R) <- vnames
+  cap <- NULL; cap_cs <- NULL
+  local_mocked_bindings(
+    susie_rss = function(...) { cap <<- list(...); .fm_fake_fit(p, vnames) },
+    susie_get_cs = function(...) { cap_cs <<- list(...); list(cs = NULL, requested_coverage = 0.95) },
+    get_cs_correlation = function(...) NULL
+  )
+  susieRssPipeline(list(z = z, variant_id = vnames), ldMat = R,
+                   finemappingOpts = list(min_abs_corr = 0.9, median_abs_corr = 0.85))
+  # NOT forwarded to the fit
+  expect_false("min_abs_corr" %in% names(cap))
+  expect_false("median_abs_corr" %in% names(cap))
+  # routed to susie_get_cs
+  expect_equal(cap_cs[["min_abs_corr"]], 0.9)
+  expect_equal(cap_cs[["median_abs_corr"]], 0.85)
+})
+
+test_that("purity defaults: min_abs_corr = 0.8, median_abs_corr absent (NULL) when unset", {
+  skip_if_not_installed("susieR")
+  p <- 5; z <- rnorm(p); vnames <- paste0("chr1:", 1:p, ":A:G"); names(z) <- vnames
+  R <- diag(p); rownames(R) <- colnames(R) <- vnames
+  cap_cs <- NULL
+  local_mocked_bindings(
+    susie_rss = function(...) .fm_fake_fit(p, vnames),
+    susie_get_cs = function(...) { cap_cs <<- list(...); list(cs = NULL, requested_coverage = 0.95) },
+    get_cs_correlation = function(...) NULL
+  )
+  susieRssPipeline(list(z = z, variant_id = vnames), ldMat = R, finemappingOpts = list())
+  expect_equal(cap_cs[["min_abs_corr"]], 0.8)
+  expect_false("median_abs_corr" %in% names(cap_cs))   # omitted -> susie_get_cs default NULL
+})
+
+test_that("no L_greedy clamp: finemappingOpts L_greedy is forwarded raw, no L fabricated", {
+  skip_if_not_installed("susieR")
+  p <- 5; z <- rnorm(p); vnames <- paste0("chr1:", 1:p, ":A:G"); names(z) <- vnames
+  R <- diag(p); rownames(R) <- colnames(R) <- vnames
+  cap <- NULL
+  local_mocked_bindings(
+    susie_rss = function(...) { cap <<- list(...); .fm_fake_fit(p, vnames) },
+    susie_get_cs = function(...) list(cs = NULL, requested_coverage = 0.95),
+    get_cs_correlation = function(...) NULL
+  )
+  susieRssPipeline(list(z = z, variant_id = vnames), ldMat = R,
+                   finemappingOpts = list(L_greedy = 8))
+  expect_equal(cap[["L_greedy"]], 8)
+  expect_false("L" %in% names(cap))
 })

--- a/tests/testthat/test_univariate_pipeline.R
+++ b/tests/testthat/test_univariate_pipeline.R
@@ -1795,9 +1795,9 @@ test_that("rss: diagnostics with no CS and no high PIP => diagnostics empty", {
     diagnostics = TRUE,
     finemappingMethod = "susieRss",
     finemappingOpts = list(
-      L = 20, lGreedy = 5,
-      coverage = c(0.95, 0.7, 0.5), signalCutoff = 0.025,
-      minAbsCorr = 0.8
+      L = 20, L_greedy = 5,
+      coverage = c(0.95, 0.7, 0.5), signal_cutoff = 0.025,
+      min_abs_corr = 0.8
     )
   )
 
@@ -1814,52 +1814,37 @@ test_that("rss: finemapping_opts are forwarded to susieRssPipeline", {
   ss <- make_rss_sumstats(5)
   ld_mat <- make_rss_ld_mat(5)
 
-  captured_L <- NULL
-  captured_L_greedy <- NULL
-  captured_coverage <- NULL
-  captured_signal_cutoff <- NULL
-  captured_R_mismatch <- NULL
+  cap <- NULL
   local_mocked_bindings(
     loadRssData = function(...) list(sumstats = ss, n = 1000, varY = 1),
-    rssBasicQc = function(...) QcResult(
-      ldData = if (nrow(ld_mat) > 0) .test_lddata_from_matrix(ld_mat) else NULL,
-      rssInput = list(sumstats = ss, n = NA_real_, varY = NA_real_),
-      preprocess = list(),
-      outlierNumber = 0L,
-      skipped = FALSE
-    ),
-    susieRssPipeline = function(sumstats, ldMat, n, var_y, L, lGreedy,
-                                  analysisMethod, coverage, secondaryCoverage,
-                                  signalCutoff, minAbsCorr, ...) {
-      captured_L <<- L
-      captured_L_greedy <<- lGreedy
-      captured_coverage <<- coverage
-      captured_signal_cutoff <<- signalCutoff
-      captured_R_mismatch <<- list(...)$rMismatch
-      make_fake_post_result(5)
-    },
+    summaryStatsQc = function(...) .test_qcresult(ss, ld_mat, outlierNumber = 0),
+    susieRssPipeline = function(...) { cap <<- list(...); make_fake_post_result(5) },
   )
 
-  result <- rssAnalysisPipeline(
+  suppressMessages(rssAnalysisPipeline(
     sumstatPath = "/fake/sumstats.tsv",
     columnFilePath = "/fake/columns.yml",
     ldData = make_test_ld_data(ss$variant_id),
-    zMismatchQc = NULL,
+    zMismatchQc = "none",
     impute = FALSE,
     finemappingMethod = "susieRss",
     finemappingOpts = list(
-      L = 10, lGreedy = 3,
-      coverage = c(0.90, 0.6), signalCutoff = 0.05,
-      minAbsCorr = 0.7
-    ),
-    rMismatch = "eb"
-  )
+      L = 10, L_greedy = 3,
+      coverage = c(0.90, 0.6), signal_cutoff = 0.05,
+      R_mismatch = "eb"
+    )
+  ))
 
-  expect_equal(captured_L, 10)
-  expect_equal(captured_L_greedy, 3)
-  expect_equal(captured_coverage, 0.90)
-  expect_equal(captured_signal_cutoff, 0.05)
-  expect_equal(captured_R_mismatch, "eb")
+  # coverage / signal_cutoff are consumed as separate susieRssPipeline args;
+  # the fit keys (L, L_greedy, R_mismatch) ride the finemappingOpts passthrough.
+  expect_equal(cap[["coverage"]], 0.90)
+  expect_equal(cap[["signalCutoff"]], 0.05)
+  fmo <- cap[["finemappingOpts"]]
+  expect_equal(fmo[["L"]], 10)
+  expect_equal(fmo[["L_greedy"]], 3)
+  expect_equal(fmo[["R_mismatch"]], "eb")
+  expect_false("coverage" %in% names(fmo))
+  expect_false("signal_cutoff" %in% names(fmo))
 })
 
 # ========================================================================
@@ -2015,9 +2000,9 @@ test_that("rss: diagnostics with null/empty block_cs_metrics => no additional an
     diagnostics = TRUE,
     finemappingMethod = "susieRss",
     finemappingOpts = list(
-      L = 20, lGreedy = 5,
-      coverage = c(0.95, 0.7, 0.5), signalCutoff = 0.025,
-      minAbsCorr = 0.8
+      L = 20, L_greedy = 5,
+      coverage = c(0.95, 0.7, 0.5), signal_cutoff = 0.025,
+      min_abs_corr = 0.8
     )
   )
 
@@ -2559,4 +2544,33 @@ test_that("rss: mafCutoff skips with one warning when af is missing (no fallback
   # ...but it is NOT used: nothing filtered, all 5 variants kept.
   expect_equal(nrow(captured_ss), 5)
   expect_true("1:300:A:G" %in% captured_ss$variant_id)
+})
+
+# ========================================================================
+#  SECTION: rssAnalysisPipeline finemapping-defaults (rss-finemap-defaults §1.4)
+# ========================================================================
+
+test_that("rss: rssAnalysisPipeline forwards finemappingOpts as a passthrough list to susieRssPipeline", {
+  ss <- make_rss_sumstats(5)
+  ld_mat <- make_rss_ld_mat(5)
+  fake_result <- make_fake_post_result(5)
+  cap <- NULL
+  local_mocked_bindings(
+    loadRssData = function(...) list(sumstats = ss, n = 1000, var_y = 1),
+    summaryStatsQc = function(...) .test_qcresult(ss, ld_mat, outlierNumber = 0),
+    susieRssPipeline = function(...) { cap <<- list(...); fake_result },
+  )
+  suppressMessages(rssAnalysisPipeline(
+    sumstatPath = "/f.tsv", columnFilePath = "/c.yml",
+    ldData = make_test_ld_data(ss$variant_id),
+    zMismatchQc = "none", impute = FALSE, finemappingMethod = "susie_rss",
+    finemappingOpts = list(coverage = c(0.95, 0.7, 0.5), signal_cutoff = 0.025, L = 12, min_abs_corr = 0.9)
+  ))
+  # coverage / signal_cutoff are consumed as separate susieRssPipeline args;
+  # the rest is forwarded as the finemappingOpts passthrough (fit + purity keys).
+  fmo <- cap[["finemappingOpts"]]
+  expect_false("coverage" %in% names(fmo))
+  expect_false("signal_cutoff" %in% names(fmo))
+  expect_equal(fmo[["L"]], 12)             # fit param rides the passthrough
+  expect_equal(fmo[["min_abs_corr"]], 0.9) # purity key isolated downstream by susieRssPipeline
 })


### PR DESCRIPTION
Step 3 of the RSS-parity plan. The RSS wrappers hardcoded fine-mapping parameters that `susie_rss` already defaults, so a pipeline run with none set did not equal a manual `susie_rss` run (the plan's pipeline-vs-manual success criterion).

## What changes
- **`susieRssPipeline()`**: `L`/`lGreedy`/`minAbsCorr` default to a NULL sentinel — omit-don't-substitute. `L`/`L_greedy`/`R_finite`/`R_mismatch` go into the `susie_rss` call only when set; `computeCsTable` omits `min_abs_corr` from `susie_get_cs` when unset, so susieR's own defaults apply. The `lGreedy <- min(lGreedy, L)` clamp runs only when both are set.
- **`rssAnalysisPipeline()`**: the `finemappingOpts` default drops `L`/`L_greedy`/`min_abs_corr`; absent keys forward as unset. `coverage`/`signal_cutoff` keep pipeline defaults.

## Testing
Modified package, susieR 0.16.4: 3093 pass, 0 fail, 22 skip. On chr21 AD_Bellenguez: explicit step-1 params reproduce the step-1 credible sets exactly (max abs PIP diff 0); all-unset matches a manual `susie_rss` run (max abs PIP diff 0); flagship explicit parity holds on shared keys incl. the 2nd CS at low `min_abs_corr`.

## Follow-up
`colocWrapper()` still sets its own `finemappingOpts` defaults (out of scope here). xqtl-protocol `rss_analysis.ipynb` should adopt the camelCase API and leave these params unset to inherit susieR defaults.