### PR TITLE
RSS QC summary logging + fine-mapping vignette on current API

### DIFF
--- a/R/allele_qc.R
+++ b/R/allele_qc.R
@@ -32,7 +32,13 @@ NULL
 #' @return An \code{AlleleQcResult} S4 object. Use
 #'   \code{getHarmonizedData()} to recover the post-QC variant
 #'   data.frame and \code{getQcSummary()} to inspect the per-variant
-#'   merge/flip/strand diagnostics.
+#'   merge/flip/strand diagnostics. The object also carries a
+#'   \code{"qcCounts"} attribute (\code{attr(x, "qcCounts")}) — a list with
+#'   \code{considered}, \code{signFlip}, \code{strandFlip} (corrections applied
+#'   to retained variants), \code{kept}, \code{dropped}, and the drop breakdown
+#'   \code{droppedIndel} / \code{droppedAmbiguous} / \code{droppedOther} — used
+#'   for QC summary logging. Existing callers that read the data.frame are
+#'   unaffected.
 #' @importFrom magrittr %>%
 #' @importFrom dplyr mutate inner_join filter pull select everything row_number if_else any_of all_of rename
 #' @importFrom vctrs vec_duplicate_detect
@@ -98,7 +104,11 @@ matchRefPanel <- function(targetData, refVariants, colToFlip = NULL,
 
   if (nrow(matchResult) == 0) {
 	warning("No matching variants found between target data and reference variants.")
-	return(AlleleQcResult(harmonizedData = matchResult, qcSummary = matchResult))
+	emptyOut <- AlleleQcResult(harmonizedData = matchResult, qcSummary = matchResult)
+	attr(emptyOut, "qcCounts") <- list(considered = 0L, signFlip = 0L, strandFlip = 0L,
+	                                   kept = 0L, dropped = 0L, droppedIndel = 0L,
+	                                   droppedAmbiguous = 0L, droppedOther = 0L)
+	return(emptyOut)
   }
     # match target & ref by chrom and position
   matchResult = matchResult %>%
@@ -209,7 +219,31 @@ matchRefPanel <- function(targetData, refVariants, colToFlip = NULL,
 	stop("Duplicated variants with different values found. Please check the input data and determine which to keep.")
   }
 
-  return(AlleleQcResult(harmonizedData = result, qcSummary = matchResult))
+  # QC summary counts for logging. Corrections (sign/strand flip) are counted on
+  # retained variants; drops are split by reason. Computed from the per-variant
+  # flags still on matchResult (default removeUnmatched = TRUE path); attached as
+  # a `qcCounts` attribute so callers that read the data frame are unaffected.
+  qcCounts <- if (all(c("sign_flip", "strand_flip", "keep", "INDEL", "strand_unambiguous") %in% names(matchResult))) {
+    cnt <- list(
+      considered = nrow(matchResult),
+      signFlip = sum(matchResult$sign_flip & matchResult$keep, na.rm = TRUE),
+      strandFlip = sum(matchResult$strand_flip & matchResult$keep, na.rm = TRUE),
+      kept = sum(matchResult$keep, na.rm = TRUE),
+      dropped = sum(!matchResult$keep, na.rm = TRUE),
+      droppedIndel = sum(!matchResult$keep & matchResult$INDEL, na.rm = TRUE),
+      droppedAmbiguous = sum(!matchResult$keep & !matchResult$INDEL &
+                               matchResult$strand_flip & !matchResult$strand_unambiguous, na.rm = TRUE)
+    )
+    cnt$droppedOther <- cnt$dropped - cnt$droppedIndel - cnt$droppedAmbiguous
+    cnt
+  } else {
+    list(considered = nrow(matchResult), signFlip = 0L, strandFlip = 0L,
+         kept = nrow(matchResult), dropped = 0L, droppedIndel = 0L,
+         droppedAmbiguous = 0L, droppedOther = 0L)
+  }
+  out <- AlleleQcResult(harmonizedData = result, qcSummary = matchResult)
+  attr(out, "qcCounts") <- qcCounts
+  return(out)
 }
 
 #' @rdname matchRefPanel

--- a/R/sumstats_qc.R
+++ b/R/sumstats_qc.R
@@ -58,6 +58,7 @@ rssBasicQc <- function(sumstats, ldData, skipRegion = NULL, keepIndel = TRUE,
     removeStrandAmbiguous = TRUE
   )
 
+  bqCounts <- attr(alleleFlip, "qcCounts")
   qced <- getHarmonizedData(alleleFlip)
   if (!is.null(skipRegion)) {
     skipTable <- tibble(region = skipRegion) %>%
@@ -81,13 +82,15 @@ rssBasicQc <- function(sumstats, ldData, skipRegion = NULL, keepIndel = TRUE,
   nRef <- ldData@nRef
 
   if (!isTRUE(returnLdMat)) {
-    return(QcResult(
+    resNoLd <- QcResult(
       ldData = NULL,
       rssInput = list(sumstats = sumstatsProcessed, n = NA_real_, varY = NA_real_),
       preprocess = list(),
       outlierNumber = 0L,
       skipped = FALSE
-    ))
+    )
+    attr(resNoLd, "qcCounts") <- bqCounts
+    return(resNoLd)
   }
 
   # Align and subset LD by mapping core IDs (strip trailing build suffix) to exact LD IDs
@@ -113,7 +116,7 @@ rssBasicQc <- function(sumstats, ldData, skipRegion = NULL, keepIndel = TRUE,
 
   ldMatProcessed <- ldMatrix[sumstatsProcessed$variant_id, sumstatsProcessed$variant_id, drop = FALSE]
 
-  QcResult(
+  resFinal <- QcResult(
     ldData = .qcLdDataFromMatrix(ldMatProcessed, sumstatsProcessed$variant_id,
                                  hasGenotype = FALSE, nRef = nRef),
     rssInput = list(sumstats = sumstatsProcessed, n = NA_real_, varY = NA_real_),
@@ -121,6 +124,8 @@ rssBasicQc <- function(sumstats, ldData, skipRegion = NULL, keepIndel = TRUE,
     outlierNumber = 0L,
     skipped = FALSE
   )
+  attr(resFinal, "qcCounts") <- bqCounts
+  resFinal
 }
 
 
@@ -537,6 +542,10 @@ summaryStatsQc <- function(sumstats, ldData, n = NULL,
                       returnLdMat = !hasGenotype)
   sumstats <- getRssInput(basic)$sumstats
   basicLd <- getLdData(basic)
+  # QC logging: counts surfaced by matchRefPanel (via rssBasicQc) plus the study
+  # input size, used for "N of M" per-step messages and the per-study rollup.
+  hCounts <- attr(basic, "qcCounts")
+  nStudyIn <- nrow(rssInput$sumstats)
   R_mat <- if (is.null(basicLd)) NULL else getCorrelation(basicLd)
   n <- rssInput$n
   varY <- rssInput$varY
@@ -582,8 +591,15 @@ summaryStatsQc <- function(sumstats, ldData, n = NULL,
       nRef = ldDataForQc@nRef
     )
   }
-  message("QC track: basic harmonization retained ", nrow(sumstats),
-          " variants for summary-stat study ", study, ".")
+  harmKept <- nrow(sumstats)
+  harmDropped <- nStudyIn - harmKept
+  message("QC track: basic harmonization kept ", harmKept, " of ", nStudyIn,
+          " variant(s) for summary-stat study ", study,
+          if (!is.null(hCounts)) {
+            paste0(" (corrected: sign-flipped ", hCounts$signFlip,
+                   ", strand-flipped ", hCounts$strandFlip,
+                   "; dropped ", harmDropped, ").")
+          } else ".")
   if (nrow(sumstats) < 2) {
     return(skippedResult(sumstats, referenceForVariants(sumstats$variant_id),
                          "fewer than two variants remain after basic QC"))
@@ -607,10 +623,15 @@ summaryStatsQc <- function(sumstats, ldData, n = NULL,
   }
 
   outlierNumber <- 0L
+  krRemoved <- 0L
+  mismatchRemoved <- 0L
+  imputedBefore <- NA_integer_
+  imputedAfter <- NA_integer_
   # Optional kriging LD-consistency prefilter (opt-in). Runs before the heavier
   # SLALOM/DENTIST QC, or standalone when zMismatchQc == "none".
   if (isTRUE(alleleFlipKriging) && nrow(sumstats) >= 2) {
     message("QC track: running kriging LD-consistency prefilter for summary-stat study ", study, ".")
+    nKrIn <- nrow(sumstats)
     krLd <- ldDataWithLocalR(sumstats)
     rKr <- getCorrelation(krLd)
     rKr <- rKr[sumstats$variant_id, sumstats$variant_id, drop = FALSE]
@@ -621,11 +642,13 @@ summaryStatsQc <- function(sumstats, ldData, n = NULL,
       if (!hasGenotype) R_mat <- R_mat[sumstats$variant_id, sumstats$variant_id, drop = FALSE]
       outlierNumber <- outlierNumber + nKr
     }
-    message("QC track: kriging prefilter removed ", nKr,
+    krRemoved <- nKr
+    message("QC track: kriging prefilter removed ", nKr, " of ", nKrIn,
             " LD-inconsistent variant(s) for summary-stat study ", study, ".")
   }
   if (!is.null(zMismatchQc) && !identical(zMismatchQc, "none")) {
     message("QC track: running ", zMismatchQc, " z-score/LD-mismatch QC for summary-stat study ", study, ".")
+    nMmIn <- nrow(sumstats)
     qc <- summaryStatsQc(sumstats = sumstats, ldData = ldDataWithLocalR(sumstats),
                          n = n, method = zMismatchQc)
     qcRss <- getRssInput(qc)
@@ -634,11 +657,13 @@ summaryStatsQc <- function(sumstats, ldData, n = NULL,
     R_mat <- if (is.null(qcLd)) NULL else getCorrelation(qcLd)
     ldMismatchOutliers <- getOutlierNumber(qc)
     outlierNumber <- outlierNumber + ldMismatchOutliers
-    message("QC track: removed ", ldMismatchOutliers,
+    mismatchRemoved <- ldMismatchOutliers
+    message("QC track: removed ", ldMismatchOutliers, " of ", nMmIn,
             " LD-mismatch outlier(s) for summary-stat study ", study, ".")
   }
   if (isTRUE(impute)) {
     message("QC track: running imputation for summary-stat study ", study, ".")
+    imputedBefore <- nrow(sumstats)
     imputed <- if (hasGenotype) {
       X_ref_scaled <- scale(X_ref)
       X_ref_scaled[is.na(X_ref_scaled)] <- 0
@@ -658,7 +683,28 @@ summaryStatsQc <- function(sumstats, ldData, n = NULL,
     }
     sumstats <- imputed$resultFilter
     if (!is.null(imputed$ldMat)) R_mat <- imputed$ldMat
+    imputedAfter <- nrow(sumstats)
+    message("QC track: imputation ", imputedBefore, " -> ", imputedAfter,
+            " variant(s) (net ", sprintf("%+d", imputedAfter - imputedBefore),
+            ") for summary-stat study ", study, ".")
   }
+  # Per-study QC rollup: corrected (sign/strand flip, retained), removed (drops at
+  # each stage), imputed (added). Kept as distinct categories because imputation
+  # adds variants back, so "in -> out" is not monotonic. Skipped stages omitted.
+  correctedSeg <- if (!is.null(hCounts)) {
+    paste0("sign-flip ", hCounts$signFlip, ", strand-flip ", hCounts$strandFlip)
+  } else "n/a"
+  removedSegs <- character(0)
+  removedSegs <- c(removedSegs, paste0("harmonization ", harmDropped))
+  if (isTRUE(alleleFlipKriging)) removedSegs <- c(removedSegs, paste0("kriging ", krRemoved))
+  if (!identical(zMismatchQc, "none")) removedSegs <- c(removedSegs, paste0("mismatch ", mismatchRemoved))
+  impSeg <- if (isTRUE(impute) && !is.na(imputedAfter)) {
+    paste0(" | imputed ", sprintf("%+d", imputedAfter - imputedBefore))
+  } else ""
+  message("QC summary [", study, "]: ", nStudyIn, " in -> ", nrow(sumstats),
+          " out | corrected: ", correctedSeg,
+          " | removed: ", paste(removedSegs, collapse = ", "), impSeg)
+
   finalVars <- sumstats$variant_id
   finalLdMat <- if (hasGenotype) referenceForVariants(finalVars) else R_mat
   preprocessSumstats <- preprocess$sumstats

--- a/man/loadMultitaskRegionalData.Rd
+++ b/man/loadMultitaskRegionalData.Rd
@@ -136,10 +136,10 @@ This function loads a mixture data sets for a specific region, including individ
 or summary statistics (sumstats, LD). Run \code{loadRegionalUnivariateData} and \code{loadRssData} multiple times for different datasets
 }
 \section{Loading individual level data from multiple corhorts}{
-NA
+
 }
 
 \section{Loading summary statistics from multiple corhorts or data set}{
-NA
+
 }
 

--- a/man/matchRefPanel.Rd
+++ b/man/matchRefPanel.Rd
@@ -70,7 +70,13 @@ corresponding `colToFlip` are multiplied by -1. Default is `TRUE`.}
 An \code{AlleleQcResult} S4 object. Use
   \code{getHarmonizedData()} to recover the post-QC variant
   data.frame and \code{getQcSummary()} to inspect the per-variant
-  merge/flip/strand diagnostics.
+  merge/flip/strand diagnostics. The object also carries a
+  \code{"qcCounts"} attribute (\code{attr(x, "qcCounts")}) — a list with
+  \code{considered}, \code{signFlip}, \code{strandFlip} (corrections applied
+  to retained variants), \code{kept}, \code{dropped}, and the drop breakdown
+  \code{droppedIndel} / \code{droppedAmbiguous} / \code{droppedOther} — used
+  for QC summary logging. Existing callers that read the data.frame are
+  unaffected.
 }
 \description{
 Match by ("chrom", "A1", "A2" and "pos"), accounting for possible

--- a/tests/testthat/test_allele_qc.R
+++ b/tests/testthat/test_allele_qc.R
@@ -472,3 +472,35 @@ test_that("colToComplement errors on a missing column name", {
     "not found in targetData"
   )
 })
+
+# ===========================================================================
+# QC summary counts (rss-vignette-and-qc-logging)
+# ===========================================================================
+
+test_that("matchRefPanel surfaces sign/strand/dropped counts via qcCounts attribute", {
+  # Deterministic fixture at four shared positions:
+  #   100 exact match | 200 sign flip | 300 strand flip (A/G, unambiguous) | 400 allele mismatch (dropped)
+  target <- data.frame(
+    chrom = c(1, 1, 1, 1), pos = c(100, 200, 300, 400),
+    A2 = c("A", "A", "A", "A"), A1 = c("G", "G", "G", "G"),
+    z = c(1, 2, 3, 4), stringsAsFactors = FALSE
+  )
+  ref <- data.frame(
+    chrom = c(1, 1, 1, 1), pos = c(100, 200, 300, 400),
+    A2 = c("A", "G", "T", "C"), A1 = c("G", "A", "C", "A"), stringsAsFactors = FALSE
+  )
+  res <- matchRefPanel(target, ref, colToFlip = "z", matchMinProp = 0)
+
+  # Default return shape unchanged: kept variants only in harmonizedData.
+  expect_s4_class(res, "AlleleQcResult")
+  expect_equal(nrow(getHarmonizedData(res)), 3L)  # exact + sign + strand kept; mismatch dropped
+
+  # Counts surfaced as an attribute (additive; non-RSS callers ignore it).
+  cnt <- attr(res, "qcCounts")
+  expect_false(is.null(cnt))
+  expect_equal(cnt$considered, 4L)
+  expect_equal(cnt$signFlip, 1L)
+  expect_equal(cnt$strandFlip, 1L)
+  expect_equal(cnt$kept, 3L)
+  expect_equal(cnt$dropped, 1L)
+})

--- a/tests/testthat/test_sumstats_qc.R
+++ b/tests/testthat/test_sumstats_qc.R
@@ -415,7 +415,7 @@ test_that("summaryStatsQc basic genotype-backed path does not compute LD", {
   expect_message(
     result <- summaryStatsQc(rssInput = rss_input, ldData = LD_data_geno,
                                zMismatchQc = "none", impute = FALSE),
-    "basic harmonization retained"
+    "basic harmonization kept"
   )
   result_ld <- getLdData(result)
   result_geno <- getGenotypes(result_ld)
@@ -526,7 +526,7 @@ test_that("summaryStatsQc treats NULL qc_method as basic-only none", {
       zMismatchQc = NULL,
       impute = FALSE
     ),
-    "basic harmonization retained"
+    "basic harmonization kept"
   )
   expect_equal(nrow(getRssInput(result)$sumstats), nrow(td$sumstats))
 })
@@ -673,7 +673,7 @@ test_that("kriging is not run by default (alleleFlipKriging = FALSE)", {
       rssInput = rssInput, ldData = td$ldData,
       zMismatchQc = "none", impute = FALSE
     ),
-    "basic harmonization retained"
+    "basic harmonization kept"
   )
   expect_equal(nrow(getRssInput(result)$sumstats), nrow(td$sumstats))
 })
@@ -700,4 +700,47 @@ test_that("alleleFlipKriging drops a planted outlier and composes with zMismatch
   expect_true(is(result, "QcResult"))
   expect_equal(seenN, nrow(td$sumstats) - 1)   # kriging removed one before dentist
   expect_equal(getOutlierNumber(result), 1)
+})
+
+# ===========================================================================
+# QC summary logging (rss-vignette-and-qc-logging)
+# ===========================================================================
+
+test_that("QC track reports kept-of-considered and a per-study rollup", {
+  td <- make_test_sumstats_ld(6)
+  msgs <- capture_messages(
+    summaryStatsQc(rssInput = list(sumstats = td$sumstats, n = 1000, varY = 1),
+                   ldData = td$ldData, zMismatchQc = "none", impute = FALSE,
+                   returnOnSkip = "preprocess", study = "studyA")
+  )
+  joined <- paste(msgs, collapse = "")
+  expect_match(joined, "harmoni", ignore.case = TRUE)
+  expect_match(joined, "of [0-9]+")        # "N of M" denominator framing
+  expect_match(joined, "QC summary")       # per-study rollup line
+})
+
+test_that("kriging outliers are reported as removed-of-N (denominator), never flipped", {
+  td <- make_test_sumstats_ld(6)
+  msgs <- capture_messages(
+    summaryStatsQc(rssInput = list(sumstats = td$sumstats, n = 1000, varY = 1),
+                   ldData = td$ldData, zMismatchQc = "none",
+                   alleleFlipKriging = TRUE, impute = FALSE,
+                   returnOnSkip = "preprocess", study = "studyA")
+  )
+  joined <- paste(msgs, collapse = "")
+  expect_match(joined, "kriging", ignore.case = TRUE)
+  expect_match(joined, "removed [0-9]+ of [0-9]+", ignore.case = TRUE)
+})
+
+test_that("skipped QC steps are not reported as actions", {
+  td <- make_test_sumstats_ld(6)
+  msgs <- capture_messages(
+    summaryStatsQc(rssInput = list(sumstats = td$sumstats, n = 1000, varY = 1),
+                   ldData = td$ldData, zMismatchQc = "none",
+                   alleleFlipKriging = FALSE, impute = FALSE,
+                   returnOnSkip = "preprocess", study = "studyA")
+  )
+  joined <- paste(msgs, collapse = "")
+  expect_match(joined, "QC summary")
+  expect_false(grepl("imputed \\+[1-9]", joined))   # imputation disabled -> no positive imputed count
 })

--- a/vignettes/fine-mapping.Rmd
+++ b/vignettes/fine-mapping.Rmd
@@ -102,11 +102,11 @@ to fit via the `methods` parameter on `univariateAnalysisPipeline()`
 
 | Variant | Individual-level | Summary statistics | What it models |
 |---|---|---|---|
-| **SuSiE alone** | `methods = "susie"` | `methods = "susie_rss"` | Sparse causal effects only. No infinitesimal/background term. Lightest weight; can fold polygenic background into noisy "extra" credible sets. |
-| **SuSiE with SuSiE-inf init** (default) | `methods = c("susie_inf", "susie")` + `add_susie_inf = TRUE` | `methods = c("susie_inf_rss", "susie_rss")` + `add_susie_inf = TRUE` | Two-stage: SuSiE-inf absorbs background polygenicity first, SuSiE then refines sparse signals from that initialisation. Recommended default for most QTL and GWAS fine-mapping. |
-| **SuSiE-inf alone** | `methods = "susie_inf"` | `methods = "susie_inf_rss"` | Sparse + infinitesimal joint fit. Useful for regions with strong polygenic background where the SuSiE refinement step is undesired. |
-| **SuSiE-ash alone** | `methods = "susie_ash"` | `methods = "susie_ash_rss"` | Sparse + adaptive shrinkage (ASH) mixture. Useful when you suspect a mix of medium-effect and small-effect variants beyond a small handful of large ones. |
-| **SuSiE-ash with SuSiE-inf init** | `methods = c("susie_inf", "susie_ash")` + `add_susie_inf = TRUE` | `methods = c("susie_inf_rss", "susie_ash_rss")` + `add_susie_inf = TRUE` | Same chained two-stage idea as the SuSiE variant but with ASH on the downstream fit: SuSiE-inf absorbs polygenic background first, then SuSiE-ash refines using the mixture prior. |
+| **SuSiE alone** | `methods = "susie"` | `methods = "susieRss"` | Sparse causal effects only. No infinitesimal/background term. Lightest weight; can fold polygenic background into noisy "extra" credible sets. |
+| **SuSiE with SuSiE-inf init** (default) | `methods = c("susieInf", "susie")` + `addSusieInf = TRUE` | `methods = c("susieInfRss", "susieRss")` + `addSusieInf = TRUE` | Two-stage: SuSiE-inf absorbs background polygenicity first, SuSiE then refines sparse signals from that initialisation. Recommended default for most QTL and GWAS fine-mapping. |
+| **SuSiE-inf alone** | `methods = "susieInf"` | `methods = "susieInfRss"` | Sparse + infinitesimal joint fit. Useful for regions with strong polygenic background where the SuSiE refinement step is undesired. |
+| **SuSiE-ash alone** | `methods = "susieAsh"` | `methods = "susieAshRss"` | Sparse + adaptive shrinkage (ASH) mixture. Useful when you suspect a mix of medium-effect and small-effect variants beyond a small handful of large ones. |
+| **SuSiE-ash with SuSiE-inf init** | `methods = c("susieInf", "susieAsh")` + `addSusieInf = TRUE` | `methods = c("susieInfRss", "susieAshRss")` + `addSusieInf = TRUE` | Same chained two-stage idea as the SuSiE variant but with ASH on the downstream fit: SuSiE-inf absorbs polygenic background first, then SuSiE-ash refines using the mixture prior. |
 
 The chained SuSiE-inf → SuSiE two-stage is the default both for
 backward compatibility and because it produces clean credible sets in
@@ -114,10 +114,10 @@ most settings: SuSiE alone can fold polygenic background into noisy
 "extra" credible sets; SuSiE-inf absorbs that background first so the
 SuSiE refinement concentrates on sparse signals.
 
-`add_susie_inf = TRUE` chains SuSiE-inf into **any** of `"susie"` or
-`"susie_ash"` that appear in `methods`. Listing all three
-(`methods = c("susie_inf", "susie", "susie_ash")` with
-`add_susie_inf = TRUE`) fits SuSiE-inf once, then both SuSiE and
+`addSusieInf = TRUE` chains SuSiE-inf into **any** of `"susie"` or
+`"susieAsh"` that appear in `methods`. Listing all three
+(`methods = c("susieInf", "susie", "susieAsh")` with
+`addSusieInf = TRUE`) fits SuSiE-inf once, then both SuSiE and
 SuSiE-ash initialised from it — useful for direct head-to-head
 comparison on the same warm start.
 
@@ -134,19 +134,19 @@ the `method` column.
 > means head-to-head differences only show up on regions with at
 > least one sparse signal.
 
-### Backward compatibility with `add_susie_inf`
+### Backward compatibility with `addSusieInf`
 
-The pre-existing `add_susie_inf` boolean still works exactly as before
+The pre-existing `addSusieInf` boolean still works exactly as before
 when `methods` is `NULL` (the default):
 
-- `add_susie_inf = TRUE` (default) → fit SuSiE-inf, then chain it into
-  SuSiE. Equivalent to `methods = c("susie_inf", "susie")`.
-- `add_susie_inf = FALSE` → plain SuSiE alone. Equivalent to
+- `addSusieInf = TRUE` (default) → fit SuSiE-inf, then chain it into
+  SuSiE. Equivalent to `methods = c("susieInf", "susie")`.
+- `addSusieInf = FALSE` → plain SuSiE alone. Equivalent to
   `methods = "susie"`.
 
-When `methods` is set explicitly, `add_susie_inf` controls whether the
-chained-init shortcut is applied to any `"susie"` or `"susie_ash"`
-method that appears alongside `"susie_inf"`. Set `add_susie_inf = FALSE`
+When `methods` is set explicitly, `addSusieInf` controls whether the
+chained-init shortcut is applied to any `"susie"` or `"susieAsh"`
+method that appears alongside `"susieInf"`. Set `addSusieInf = FALSE`
 to fit each requested method independently rather than chained.
 
 ### Fitting multiple variants in one call
@@ -154,7 +154,7 @@ to fit each requested method independently rather than chained.
 ```{r multi-method-fit, eval=FALSE}
 multi <- univariateAnalysisPipeline(
   X = X[, sub], Y = y, maf = maf[sub],
-  methods = c("susie_inf", "susie", "susie_ash"),
+  methods = c("susieInf", "susie", "susieAsh"),
   twasWeights = FALSE,
   signalCutoff = 0
 )
@@ -168,7 +168,7 @@ If you want the raw fits without `pecotmr`'s post-processing:
 
 ```{r two-stage-fit, eval=FALSE}
 # Two-stage convenience for the recommended default:
-fits <- fit_susie_inf_then_susie(X[, sub], y)         # list(susie, susie_inf)
+fits <- fitSusieInfThenSusie(X[, sub], y)             # list(susie, susieInf)
 fits_rss <- fitSusieInfThenSusieRss(z, R, n)
 
 # Or call susieR directly with the right unmappable_effects flag:
@@ -179,11 +179,11 @@ ash_fit <- susieR::susie(X, y, unmappable_effects = "ash",
 
 # Then post-process any combination through the unified pipeline:
 post <- postprocessFinemappingFits(
-  fits = list(susie_inf = inf_fit, susie_ash = ash_fit),
-  data_x = X[, sub], data_y = y, maf = maf[sub],
-  coverage = 0.95, secondary_coverage = c(0.7, 0.5)
+  fits = list(susieInf = inf_fit, susieAsh = ash_fit),
+  dataX = X[, sub], dataY = y, af = maf[sub],
+  coverage = 0.95, secondaryCoverage = c(0.7, 0.5)
 )
-out <- formatFinemappingOutput(post, primary_method = "susie_inf")
+out <- formatFinemappingOutput(post, primaryMethod = "susieInf")
 ```
 
 ## The unified `top_loci` table
@@ -199,10 +199,10 @@ following 22 columns, in this order:
 |  4 | `a1`                    | from parsed `variant`                                  |
 |  5 | `a2`                    | from parsed `variant`                                  |
 |  6 | `variant`               | the row's variant id (`chr:pos:A2:A1`)                 |
-|  7 | `gene`                  | phenotype identifier (`colnames(data_y)[1]`)           |
+|  7 | `gene`                  | phenotype identifier (`colnames(dataY)[1]`)            |
 |  8 | `event`                 | `paste(condition_id, gene, sep = "_")`                 |
 |  9 | `n`                     | analyzed sample count                                  |
-| 10 | `maf`                   | from the `maf` argument                                |
+| 10 | `af`                    | effect-allele frequency (`af`; complemented on allele swaps) |
 | 11 | `beta`                  | univariate effect (`sumstats$betahat`)                 |
 | 12 | `se`                    | univariate SE (`sumstats$sebetahat`)                   |
 | 13 | `pip`                   | per-variant SuSiE PIP                                  |
@@ -273,22 +273,22 @@ n_qtl_sample      <- 0  # 0 = read from sumstats
 ld_data <- loadLdMatrix(ld_meta_path, region = region)
 
 fm <- rssAnalysisPipeline(
-  sumstat_path        = qtl_sumstat_path,
-  column_file_path    = qtl_column_map,
-  LD_data             = ld_data,
-  n_sample            = n_qtl_sample,
+  sumstatPath         = qtl_sumstat_path,
+  columnFilePath      = qtl_column_map,
+  ldData              = ld_data,
+  nSample             = n_qtl_sample,
   region              = region,
-  extract_region_name = gene_id,
-  region_name_col     = 4L,
-  qc_method           = "slalom",
-  finemapping_method  = "susie_rss",
-  finemapping_opts    = list(L = 20, L_greedy = 5,
+  extractRegionName   = gene_id,
+  regionNameCol       = 4L,
+  zMismatchQc         = "slalom",
+  finemappingMethod   = "susieRss",
+  finemappingOpts     = list(L = 20, L_greedy = 5,
                              coverage = c(0.95, 0.7, 0.5),
-                             signalCutoff = 0.025,
+                             signal_cutoff = 0.025,
                              min_abs_corr = 0.8),
   impute              = TRUE
 )
-head(fm$rss_data_analyzed[[1]]$top_loci)
+head(fm$rssDataAnalyzed[[1]]$top_loci)
 ```
 
 ### Lower-level alternative (in-memory, runnable here)
@@ -312,12 +312,12 @@ R_sub    <- R[sumstats$variant_id, sumstats$variant_id]
 
 fm_rss <- susieRssPipeline(
   sumstats          = sumstats,
-  LD_mat            = R_sub,
+  ldMat             = R_sub,
   n                 = nrow(X_ref),
-  L                 = 10, L_greedy = 5,
-  analysis_method   = "susie_rss",
+  analysisMethod    = "susieRss",
   coverage          = 0.95,
-  secondary_coverage = c(0.7, 0.5)
+  secondaryCoverage = c(0.7, 0.5),
+  finemappingOpts   = list(L = 10, L_greedy = 5)
 )
 names(fm_rss)
 dim(fm_rss$top_loci)
@@ -326,9 +326,10 @@ head(fm_rss$top_loci[, c("variant", "pip", "cs_95",
 ```
 
 Note that the output schema is the same 22 columns as the
-individual-level pipeline — `method` is `"susie_rss"` instead of
-`"susie"`, but everything downstream (ColocBoost, xqtl-enrichment,
-TWAS) consumes the same table.
+individual-level pipeline — the `method` column reads `"susie_rss"`
+instead of `"susie"` (the output `method` values stay snake_case even
+though the `methods` argument is camelCase), but everything downstream
+(ColocBoost, xqtl-enrichment, TWAS) consumes the same table.
 
 ## GWAS summary-statistics fine-mapping
 
@@ -341,9 +342,9 @@ layer:
   [RSS QC vignette](rss-qc.html) shows the YAML schema; common GWAS
   alternatives are `effect_allele`/`other_allele` for `A1`/`A2`,
   `OR` (you'll need `log(OR)` for `beta`), and `N` for `n_sample`.
-- **No `extract_region_name`.** GWAS sumstats are not gene-keyed, so
+- **No `extractRegionName`.** GWAS sumstats are not gene-keyed, so
   you slice by physical region only. Pass `region = "chr:start-end"`
-  and omit `extract_region_name` / `region_name_col`.
+  and omit `extractRegionName` / `regionNameCol`.
 - **Per-variant sample size.** GWAS sumstats often have a per-variant
   `n_sample` column (some variants were imputed in fewer cohorts);
   `loadRssData()` reads that automatically when the column is mapped.
@@ -358,14 +359,14 @@ region            <- "<chr:start-end>"
 ld_data <- loadLdMatrix(ld_meta_path, region = region)
 
 fm_gwas <- rssAnalysisPipeline(
-  sumstat_path       = gwas_sumstat_path,
-  column_file_path   = gwas_column_map,
-  LD_data            = ld_data,
-  n_case             = 0,        # set if known; 0 reads from sumstats
-  n_control          = 0,
+  sumstatPath        = gwas_sumstat_path,
+  columnFilePath     = gwas_column_map,
+  ldData             = ld_data,
+  nCase              = 0,        # set if known; 0 reads from sumstats
+  nControl           = 0,
   region             = region,
-  qc_method          = "slalom",
-  finemapping_method = "susie_rss",
+  zMismatchQc        = "slalom",
+  finemappingMethod  = "susieRss",
   impute             = TRUE
 )
 ```
@@ -397,7 +398,7 @@ workflows:
   of QTL fine-mapping signals at GWAS PIPs. See the
   [enrichment vignette](xqtl-enrichment.html).
 - **Colocalization** (`colocboostPipeline`): uses the trimmed SuSiE
-  fits — `finemapping_result` slot — as colocalization input. See the
+  fits — `finemappingResult` slot — as colocalization input. See the
   [ColocBoost vignette](colocboost-pipeline.html).
 - **TWAS** (`twasWeightsPipeline`, `twasPipeline`): uses the SuSiE
   effect estimates as weight learners for transcriptome-wide
@@ -409,11 +410,11 @@ workflows:
 
 | Function | Use it when |
 |---|---|
-| `univariateAnalysisPipeline()` | Individual-level data: you have `X` (samples × variants), `Y` (phenotype). Pick variant(s) via `methods = c("susie", "susie_inf", "susie_ash")`. |
-| `rssAnalysisPipeline()` | Summary statistics (QTL or GWAS): you have z-scores in a tabix file and an LD reference. Pick variant(s) via `methods = c("susie_rss", "susie_inf_rss", "susie_ash_rss")`. |
+| `univariateAnalysisPipeline()` | Individual-level data: you have `X` (samples × variants), `Y` (phenotype). Pick variant(s) via `methods = c("susie", "susieInf", "susieAsh")`. |
+| `rssAnalysisPipeline()` | Summary statistics (QTL or GWAS): you have z-scores in a tabix file and an LD reference. Pick variant(s) via `methods = c("susieRss", "susieInfRss", "susieAshRss")`. |
 | `susieRssPipeline()` | Lower-level: you already have in-memory `z`, `R` (or `X`), `n`. Same `methods` argument as `rssAnalysisPipeline()`. |
-| `fit_susie_inf_then_susie()` / `fitSusieInfThenSusieRss()` | Lowest-level convenience for the two-stage chained default (SuSiE-inf init → SuSiE). |
-| `postprocessFinemappingFits()` + `formatFinemappingOutput()` | Post-process any combination of `susie`, `susie_inf`, `susie_ash`, `susie_rss`, `susie_inf_rss`, `susie_ash_rss`, `mvsusie`, `fsusie` fits into the unified 22-column `top_loci`. |
+| `fitSusieInfThenSusie()` / `fitSusieInfThenSusieRss()` | Lowest-level convenience for the two-stage chained default (SuSiE-inf init → SuSiE). |
+| `postprocessFinemappingFits()` + `formatFinemappingOutput()` | Post-process any combination of `susie`, `susieInf`, `susieAsh`, `susieRss`, `susieInfRss`, `susieAshRss`, `mvsusie`, `fsusie` fits into the unified 22-column `top_loci`. |
 
 All five entry points produce — or can be post-processed into — the
 same 22-column `top_loci` table documented above, which is the contract


### PR DESCRIPTION
## What

Two pecotmr-only follow-ups deferred by the earlier RSS steps.

**Per-step QC summary logging.** The summary-statistics QC track now reports how many
variants of how many each step touched, with the right verb per category:

- harmonization: `kept N of M (corrected: sign-flipped A, strand-flipped B; dropped C)`
- kriging / SLALOM / DENTIST: `removed D of N` (outliers dropped, never "flipped")
- imputation: `before -> after (net +K)`
- a per-study rollup keeping corrected / removed / imputed distinct, e.g.
  `QC summary [study]: 9633 in -> 10184 out | corrected: sign-flip 0, strand-flip 0 | removed: harmonization 1 | imputed +552`

The counts already existed but were discarded: `matchRefPanel` now exposes them via a
`qcCounts` attribute (default return shape unchanged, non-RSS callers unaffected),
`rssBasicQc` threads them through, and the orchestrator logs them.

**Fine-mapping vignette.** `vignettes/fine-mapping.Rmd` was broken by the camelCase
refactor and the finemappingOpts/af changes. It now uses the current API (`ldData`,
`zMismatchQc`, `finemappingMethod`, fit params inside `finemappingOpts`, `top_loci.af`)
and knits end-to-end.

## Guarantee

Logging is observability only. On chr21 AD_Bellenguez the QC result and credible sets
are byte-identical to the pre-logging code: variant set identical, max |ΔPIP| = 0,
CS membership identical, max |Δpurity| = 0.

## Tests

- New `matchRefPanel` qcCounts test and QC-track message tests (N-of-M, rollup,
  skipped-step correctness, removed-not-flipped).
- Full suite green: 1233 tests, 0 failed, 3222 passed (susieR 0.16.5).
- Vignette knits against the modified package.

Out of scope (tracked in OpenSpec `xqtl-protocol-rss-api-sync`): the xqtl-protocol
notebook migration and SoS end-to-end parity. A CI/pixi susieR bump to exercise
median_abs_corr end-to-end is flagged for later.
