### PR TITLE
Reconcile chr-prefix conventions in the LD-sketch lookup

### DIFF
--- a/R/ld.R
+++ b/R/ld.R
@@ -548,7 +548,21 @@ loadLdFromGenotype <- function(genotypePath, region,
   }
   onMissing <- match.arg(onMissing)
   snpInfo <- getSnpInfo(ldSketch)
-  idx <- match(variantIds, as.character(snpInfo$SNP))
+  # Reconcile a pure chr-prefix mismatch between the requested ids and the
+  # panel (ensureChrMatch, variantId.R) before matching, so variants that
+  # differ only by a leading "chr" still resolve instead of reading as absent.
+  # The caller's original variantIds are kept for the returned labels; only the
+  # match keys are normalized. Fall back to the raw ids if normalization can't
+  # parse them (e.g. an rsID panel), preserving prior behavior.
+  matchIds <- variantIds
+  panelIds <- as.character(snpInfo$SNP)
+  reconciled <- tryCatch(ensureChrMatch(variantIds, panelIds),
+                         error = function(e) NULL)
+  if (!is.null(reconciled)) {
+    matchIds <- reconciled$idsA
+    panelIds <- reconciled$idsB
+  }
+  idx <- match(matchIds, panelIds)
   if (anyNA(idx)) {
     if (onMissing == "error") {
       stop(sprintf("%s: %d variant id(s) not present in the LD sketch panel.",

--- a/tests/testthat/test_ld.R
+++ b/tests/testthat/test_ld.R
@@ -2841,6 +2841,50 @@ test_that(".ldFromSketch drops variants absent from the panel when onMissing='dr
 })
 
 # =============================================================================
+# Additional coverage: .ldFromSketch reconciles chr-prefix conventions
+# =============================================================================
+
+test_that(".ldFromSketch resolves chr-prefixed request ids against a non-prefixed panel", {
+  skip_if_not_installed("pgenlibr")
+  h <- readGenotypes(file.path(geno_test_data_dir, "test_variants"), format = "plink2")
+  pid <- as.character(getSnpInfo(h)$SNP)            # chr-prefixed (chr21_..._C_G)
+  h@snpInfo$SNP <- sub("^chr", "", pid)             # panel now lacks the prefix
+  m <- pecotmr:::.ldFromSketch(h, pid[1:3])         # request keeps the prefix
+  expect_equal(dim(m), c(3L, 3L))
+  expect_equal(rownames(m), pid[1:3])               # caller's labels preserved
+  expect_equal(unname(diag(m)), c(1, 1, 1))
+})
+
+test_that(".ldFromSketch resolves non-prefixed request ids against a chr-prefixed panel", {
+  skip_if_not_installed("pgenlibr")
+  h <- readGenotypes(file.path(geno_test_data_dir, "test_variants"), format = "plink2")
+  pid <- as.character(getSnpInfo(h)$SNP)
+  req <- sub("^chr", "", pid[1:3])                  # request drops the prefix
+  m <- pecotmr:::.ldFromSketch(h, req)
+  expect_equal(dim(m), c(3L, 3L))
+  expect_equal(rownames(m), req)                    # caller's labels preserved
+})
+
+test_that(".ldFromSketch is unchanged when request and panel share a convention", {
+  skip_if_not_installed("pgenlibr")
+  h <- readGenotypes(file.path(geno_test_data_dir, "test_variants"), format = "plink2")
+  pid <- as.character(getSnpInfo(h)$SNP)
+  m <- pecotmr:::.ldFromSketch(h, pid[1:3])
+  expect_equal(dim(m), c(3L, 3L))
+  expect_equal(rownames(m), pid[1:3])
+})
+
+test_that(".ldFromSketch still errors on a genuinely-absent variant after reconciliation", {
+  skip_if_not_installed("pgenlibr")
+  h <- readGenotypes(file.path(geno_test_data_dir, "test_variants"), format = "plink2")
+  pid <- as.character(getSnpInfo(h)$SNP)
+  # request the prefix-stripped form (forces reconciliation) plus one truly-absent variant
+  req <- c(sub("^chr", "", pid[1]), "21_99999999_A_G")
+  expect_error(pecotmr:::.ldFromSketch(h, req),
+               "not present in the LD sketch panel")
+})
+
+# =============================================================================
 # Additional coverage: .requireMatchingLdSketches error paths
 # =============================================================================
 


### PR DESCRIPTION
`.ldFromSketch` matched requested variant ids against the panel with a raw string match, so genotype-LD fine-mapping (GWAS + QTL) errored with "variant id(s) not present in the LD sketch panel" whenever the entry ids and panel ids referred to the same variants but disagreed only on the `chr` prefix. pecotmr already ships `ensureChrMatch`/`normalizeVariantId` (variantId.R) but wired them in nowhere. This routes the lookup through `ensureChrMatch` before matching, preserving the caller's labels and the genuinely-absent error.

Tests: prefixed/non-prefixed both directions, same-convention regression, absent-still-errors; test_ld 469/0, test_fineMappingPipeline 385/0, test_sumstatsQc 799/0. Validated on the protocol_example chr22 MWE (common path unchanged; a stripped-prefix panel now resolves).