### PR TITLE
Add ser (single-effect) fine-mapping method for GWAS RSS

### DIFF
--- a/R/fineMappingPipeline.R
+++ b/R/fineMappingPipeline.R
@@ -30,6 +30,11 @@
 #'           variant of the same.}
 #'     \item{\code{susieAsh}}{\code{unmappable_effects = "ash"}
 #'           variant of the same.}
+#'     \item{\code{ser}}{Single-effect regression via
+#'           \code{susieR::susie_ser} on GWAS summary statistics
+#'           (\code{z}, \code{n}); LD-free (no \code{R}, no \code{L}),
+#'           so distinct from \code{susie} with \code{L = 1}.
+#'           \strong{GwasSumStats input only}; errors on QTL inputs.}
 #'     \item{\code{mvsusie}}{\code{mvsusieR::mvsusie} on individual-
 #'           level input (requires multi-trait OR multi-context Y),
 #'           \code{mvsusieR::mvsusie_rss} on sumstat input (requires
@@ -290,6 +295,19 @@ setGeneric("fineMappingPipeline",
     gwasAllowed       = TRUE,
     unmappableEffects = "ash",
     args              = list()),
+  # Single-effect regression (SER) on GWAS summary statistics via
+  # susieR::susie_ser. LD-free (z + n; no R, no L), so it is distinct from
+  # susie with L = 1. GWAS-only for now (gwasOnly = TRUE); individualImpl is
+  # NULL so the QtlDataset paths reject it, and gwasOnly makes QtlSumStats
+  # reject it too.
+  ser = list(
+    individualImpl    = NULL,
+    sumstatImpl       = "susieR::susie_ser",
+    multivariate      = FALSE,
+    gwasAllowed       = TRUE,
+    gwasOnly          = TRUE,
+    unmappableEffects = NA_character_,
+    args              = list()),
   mvsusie = list(
     individualImpl    = "mvsusieR::mvsusie",
     sumstatImpl       = "mvsusieR::mvsusie_rss",
@@ -390,6 +408,11 @@ setGeneric("fineMappingPipeline",
       next
     }
     info <- caps[[tk]]
+    if (isTRUE(info$gwasOnly) && inputKind != "GwasSumStats") {
+      bad <- c(bad, tk)
+      reason <- c(reason, "is GWAS-only (requires a GwasSumStats input)")
+      next
+    }
     if (inputKind %in% individualKinds) {
       if (is.null(info$individualImpl)) {
         bad <- c(bad, tk)
@@ -1119,6 +1142,19 @@ setGeneric("fineMappingPipeline",
   # All susie_rss fits get the "susieRss" S3 class for post-processing
   # (this drives the Xcorr cs-input mode). Token-level distinction stays
   # in the `method` column of the FineMappingResult.
+  .setFinemappingFitClass(fit, "susieRss")
+}
+
+
+# Single-effect (SER) sumstat fit for GWAS: susieR::susie_ser on z + n. LD-free
+# (no R, no L, no unmappable_effects), so it cannot reuse .fmFitSusieRss. Returns
+# a susie-class object tagged "susieRss" so the shared post-processing (credible
+# sets + purity against the LD sketch) applies unchanged.
+# @noRd
+.fmFitSusieSer <- function(z, n, coverage = 0.95, userArgs = NULL) {
+  baseArgs <- list(z = z, n = n, coverage = coverage)
+  baseArgs <- .fmMergeUserArgs(baseArgs, "ser", userArgs)
+  fit <- do.call(susieR::susie_ser, baseArgs)
   .setFinemappingFitClass(fit, "susieRss")
 }
 
@@ -2112,6 +2148,12 @@ setMethod("fineMappingPipeline", "GwasSumStats",
         if (tk == "susieInf") {
           if (!chainLocal$keepInf) next
           fit <- infFit
+        } else if (tk == "ser") {
+          if (verbose >= 1)
+            message(sprintf("Fitting ser (RSS single-effect) for GWAS (study='%s', region='%s') ...",
+                            st, region_id))
+          fit <- .fmFitSusieSer(z, n, coverage = coverage,
+                                userArgs = methodArgs[["ser"]])
         } else {
           chainFrom <- if ((tk == "susie"    && chainLocal$chainSusie) ||
                            (tk == "susieAsh" && chainLocal$chainAsh))

--- a/tests/testthat/test_fineMappingPipeline.R
+++ b/tests/testthat/test_fineMappingPipeline.R
@@ -1438,6 +1438,33 @@ test_that("fineMappingPipeline(GwasSumStats): non-RSS family rejected by capabil
   )
 })
 
+test_that("fineMappingPipeline(GwasSumStats): ser dispatches to susie_ser", {
+  gss <- .fmp_makeGwasSumStats()
+  local_mocked_bindings(
+    extractBlockGenotypes = .fmp_mockExtractor(),
+    .fmFitSusieSer        = function(z, n, coverage = 0.95, userArgs = NULL)
+                              list(token = "ser", n_variants = length(z)),
+    .fmPostprocessOne     = .fmp_mockPostprocess(),
+    .package = "pecotmr")
+  res <- suppressMessages(fineMappingPipeline(gss, methods = "ser"))
+  expect_s4_class(res, "GwasFineMappingResult")
+  expect_equal(nrow(res), 1L)
+  expect_setequal(getMethodNames(res), "ser")
+})
+
+test_that(".fmCheckMethodCapabilities: ser is GWAS-only", {
+  expect_error(pecotmr:::.fmCheckMethodCapabilities("ser", "QtlSumStats"), "GWAS-only")
+  expect_error(pecotmr:::.fmCheckMethodCapabilities("ser", "QtlDataset"),  "GWAS-only")
+  expect_error(pecotmr:::.fmCheckMethodCapabilities("ser", "MultiStudyQtlDataset"), "GWAS-only")
+  expect_silent(pecotmr:::.fmCheckMethodCapabilities("ser", "GwasSumStats"))
+})
+
+test_that(".fmNormalizeMethods: ser is not seeded with L / L_greedy", {
+  norm <- pecotmr:::.fmNormalizeMethods("ser", L = 20L, Lgreedy = 5L)
+  expect_null(norm$methodArgs[["ser"]][["L"]])
+  expect_null(norm$methodArgs[["ser"]][["L_greedy"]])
+})
+
 # ===========================================================================
 # fineMappingPipeline(ANY)
 # ===========================================================================


### PR DESCRIPTION
Adds a `ser` method token → `susieR::susie_ser` on the GwasSumStats/RSS path: an LD-free single-effect regression (takes z + n, no R, no L), distinct from `susie` with L=1. GWAS-only (a `gwasOnly` capability guard rejects it on QtlDataset/QtlSumStats with a clear message). Since `susie_ser` returns a susie-class object, it flows through the existing FineMappingEntry post-processing, with credible-set purity still computed against the LD sketch. Restores the legacy `univariate_rss` `single_effect` option to the current API.

Tests: ser dispatch → GwasFineMappingResult; rejected on QTL inputs; no L injected. test_fineMappingPipeline 394/0, plus wrappers/sumstatsQc/ld suites green. Validated with a real susie_ser fit on the protocol_example chr22 MWE.