### PR TITLE
Kriging QC: flip allele-switched z instead of dropping

### DIFF
--- a/R/sumstatsQc.R
+++ b/R/sumstatsQc.R
@@ -2001,28 +2001,33 @@ ldMismatchQc <- function(zScore, R = NULL, X = NULL, nSample = NULL,
 #' Flags variants whose observed z-score is inconsistent with the value
 #' predicted from its LD neighbours, using susieR's kriging diagnostic.
 #' \code{susieR::kriging_rss()} computes the leave-one-out conditional
-#' distribution of each \code{z_i} given the rest, with the LD-mismatch scale
-#' \code{s} estimated by \code{susieR::estimate_s_rss()}; its standardized
-#' residual (\code{z_std_diff}) is ~\code{N(0,1)} when z-scores and LD agree, so
-#' a large residual marks an allele-flip / LD-mismatch outlier. RSS-only helper,
-#' opt-in via \code{alleleFlipKriging}; never wired into \code{alleleQc()} /
+#' distribution of each \code{z_i} given the rest (with the LD-mismatch scale
+#' \code{s} defaulting to \code{susieR::estimate_s_rss()}) and a per-variant
+#' \code{logLR} for the allele-switch hypothesis. This helper reuses susieR's
+#' own allele-switch rule --- \code{logLR > logLRThreshold & abs(z) > zThreshold}
+#' (the same \code{logLR > 2 & |z| > 2} used in \code{susie_rss_utils}) --- to
+#' flag variants whose sign should be flipped. RSS-only helper, opt-in via
+#' \code{alleleFlipKriging}; never wired into \code{alleleQc()} /
 #' \code{matchRefPanel()}. Requires a susieR that provides \code{kriging_rss()}
 #' and \code{estimate_s_rss()}.
 #'
 #' @param zScore Numeric vector of harmonized z-scores.
 #' @param R Square LD correlation matrix aligned to \code{zScore}.
-#' @param n Sample size, forwarded to \code{susieR::estimate_s_rss()} and
-#'   \code{susieR::kriging_rss()}.
+#' @param n Sample size, forwarded to \code{susieR::kriging_rss()} (whose
+#'   default \code{s} is \code{susieR::estimate_s_rss()}).
 #' @param variantIds Optional variant IDs for the diagnostics table.
-#' @param pThreshold Two-sided p-value cutoff for flagging an outlier
-#'   (default \code{5e-8}).
-#' @return A list with \code{outlier} (logical vector) and \code{diagnostics}
-#'   (data frame of per-variant predicted z, residual, statistic, p-value, and
-#'   outlier flag).
+#' @param zThreshold Absolute-z cutoff for the allele-switch rule
+#'   (default \code{2}, matching susieR).
+#' @param logLRThreshold Log-likelihood-ratio cutoff for the allele-switch rule
+#'   (default \code{2}, matching susieR).
+#' @return A list with \code{flip} (logical vector; \code{TRUE} = allele switch,
+#'   z-score should be sign-flipped) and \code{diagnostics} (data frame of
+#'   per-variant \code{z}, \code{condmean}, \code{z_std_diff}, \code{logLR}, and
+#'   the \code{flipped} flag).
 #' @importFrom stats pnorm
 #' @export
 krigingOutlierQc <- function(zScore, R, n, variantIds = NULL,
-                             pThreshold = 5e-8) {
+                             zThreshold = 2, logLRThreshold = 2) {
   zScore <- as.numeric(zScore)
   m <- length(zScore)
   if (is.null(R) || !is.matrix(R) || nrow(R) != m || ncol(R) != m) {
@@ -2040,23 +2045,22 @@ krigingOutlierQc <- function(zScore, R, n, variantIds = NULL,
     # nocov end
   }
   if (is.null(variantIds)) variantIds <- rownames(R)
-  # susieR's kriging RSS diagnostic: estimate the LD-mismatch scale, then take
-  # the per-variant conditional distribution. `z_std_diff` is the standardized
-  # residual we threshold (same p-value rule as before).
-  s  <- tryCatch(susieR::estimate_s_rss(z = zScore, R = R, n = n),
-                 error = function(e) 0)
-  cd <- susieR::kriging_rss(z = zScore, R = R, n = n, s = s)$conditional_dist
-  condMean  <- as.numeric(cd$condmean)
-  statistic <- as.numeric(cd$z_std_diff)
-  residual  <- zScore - condMean
-  pValue    <- .zToPvalue(statistic)
-  outlier   <- !is.na(pValue) & pValue < pThreshold
+  # susieR's kriging RSS diagnostic. Called exactly as the single-panel/notebook
+  # call (`kriging_rss(z, R, n)`), so `s` defaults to estimate_s_rss() and the
+  # returned `logLR` matches susieR's own allele-switch selection.
+  cd <- susieR::kriging_rss(z = zScore, R = R, n = n)$conditional_dist
+  condMean <- as.numeric(cd$condmean)
+  zStdDiff <- as.numeric(cd$z_std_diff)
+  logLR    <- as.numeric(cd$logLR)
+  # susieR's allele-switch rule (susie_rss_utils.R): logLR > 2 & |z| > 2.
+  flip <- !is.na(logLR) & !is.na(zScore) &
+    logLR > logLRThreshold & abs(zScore) > zThreshold
   list(
-    outlier = outlier,
+    flip = flip,
     diagnostics = data.frame(
       variant_id = if (is.null(variantIds)) seq_len(m) else variantIds,
-      z = zScore, predicted = condMean, residual = residual,
-      statistic = statistic, p_value = pValue, outlier = outlier,
+      z = zScore, condmean = condMean, z_std_diff = zStdDiff, logLR = logLR,
+      flipped = flip,
       stringsAsFactors = FALSE
     )
   )
@@ -2570,7 +2574,7 @@ krigingOutlierQc <- function(zScore, R, n, variantIds = NULL,
   # from the rollup.
   qcCount <- list(
     harmCorrSign = 0L, harmCorrStrand = 0L, harmDropped = 0L,
-    krigingRemoved = 0L, mismatchRemoved = 0L,
+    krigingFlipped = 0L, mismatchRemoved = 0L,
     imputeBefore = NA_integer_, imputeAfter = NA_integer_)
   lbl <- if (!is.null(entryLabel) && nzchar(entryLabel)) entryLabel
          else NA_character_
@@ -2706,7 +2710,9 @@ krigingOutlierQc <- function(zScore, R, n, variantIds = NULL,
     if (isTRUE(pip$skipped)) entryAudit$pipScreenReason <- pip$reason
   }
 
-  # 6. Optional kriging prefilter.
+  # 6. Optional kriging allele-flip QC. Uses susieR's allele-switch rule
+  #    (logLR > 2 & |z| > 2) to sign-flip inconsistent z-scores in place --
+  #    variants are corrected and RETAINED, not dropped.
   if (isTRUE(opts$alleleFlipKriging) && nrow(df) >= 2L) {
     nKrIn <- nrow(df)
     R <- .ldFromSketch(ldSketch, df$SNP,
@@ -2714,11 +2720,15 @@ krigingOutlierQc <- function(zScore, R, n, variantIds = NULL,
     nKrig <- if (!is.null(opts$nForPip) && is.finite(opts$nForPip)) opts$nForPip
              else stats::median(as.numeric(df$N), na.rm = TRUE)
     kr <- krigingOutlierQc(df$Z, R, n = nKrig, variantIds = df$SNP)
-    nKr <- sum(kr$outlier)
-    if (nKr > 0L) df <- df[!kr$outlier, , drop = FALSE]
-    entryAudit$krigingOutliersDropped <- nKr
-    qcCount$krigingRemoved <- nKr
-    emit("QC track: kriging prefilter removed ", nKr, " of ", nKrIn,
+    nKr <- sum(kr$flip)
+    if (nKr > 0L) {
+      df$Z[kr$flip] <- -df$Z[kr$flip]
+      if ("BETA" %in% colnames(df)) df$BETA[kr$flip] <- -df$BETA[kr$flip]
+    }
+    entryAudit$krigingFlipped <- nKr
+    entryAudit$krigingDiagnostics <- kr$diagnostics
+    qcCount$krigingFlipped <- nKr
+    emit("QC track: kriging sign-flipped ", nKr, " of ", nKrIn,
          " LD-inconsistent variant(s).")
   }
 
@@ -2849,14 +2859,14 @@ krigingOutlierQc <- function(zScore, R, n, variantIds = NULL,
   if (qcCount$harmDropped > 0L)
     removedSegs <- c(removedSegs,
                      paste0("harmonization ", qcCount$harmDropped))
-  if (isTRUE(opts$alleleFlipKriging))
-    removedSegs <- c(removedSegs,
-                     paste0("kriging ", qcCount$krigingRemoved))
   if (!identical(opts$zMismatchQc, "none"))
     removedSegs <- c(removedSegs,
                      paste0("mismatch ", qcCount$mismatchRemoved))
   correctedSeg <- paste0("sign-flip ", qcCount$harmCorrSign,
                           ", strand-flip ", qcCount$harmCorrStrand)
+  if (isTRUE(opts$alleleFlipKriging))
+    correctedSeg <- paste0(correctedSeg,
+                           ", kriging-flip ", qcCount$krigingFlipped)
   impSeg <- if (isTRUE(opts$impute) && !is.na(qcCount$imputeAfter)) {
     paste0(" | imputed ",
            sprintf("%+d", qcCount$imputeAfter - qcCount$imputeBefore))

--- a/man/krigingOutlierQc.Rd
+++ b/man/krigingOutlierQc.Rd
@@ -4,35 +4,48 @@
 \alias{krigingOutlierQc}
 \title{Kriging-style LD-consistency outlier QC}
 \usage{
-krigingOutlierQc(zScore, R, n, variantIds = NULL, pThreshold = 5e-08)
+krigingOutlierQc(
+  zScore,
+  R,
+  n,
+  variantIds = NULL,
+  zThreshold = 2,
+  logLRThreshold = 2
+)
 }
 \arguments{
 \item{zScore}{Numeric vector of harmonized z-scores.}
 
 \item{R}{Square LD correlation matrix aligned to \code{zScore}.}
 
-\item{n}{Sample size, forwarded to \code{susieR::estimate_s_rss()} and
-\code{susieR::kriging_rss()}.}
+\item{n}{Sample size, forwarded to \code{susieR::kriging_rss()} (whose
+default \code{s} is \code{susieR::estimate_s_rss()}).}
 
 \item{variantIds}{Optional variant IDs for the diagnostics table.}
 
-\item{pThreshold}{Two-sided p-value cutoff for flagging an outlier
-(default \code{5e-8}).}
+\item{zThreshold}{Absolute-z cutoff for the allele-switch rule
+(default \code{2}, matching susieR).}
+
+\item{logLRThreshold}{Log-likelihood-ratio cutoff for the allele-switch rule
+(default \code{2}, matching susieR).}
 }
 \value{
-A list with \code{outlier} (logical vector) and \code{diagnostics}
-  (data frame of per-variant predicted z, residual, statistic, p-value, and
-  outlier flag).
+A list with \code{flip} (logical vector; \code{TRUE} = allele switch,
+  z-score should be sign-flipped) and \code{diagnostics} (data frame of
+  per-variant \code{z}, \code{condmean}, \code{z_std_diff}, \code{logLR}, and
+  the \code{flipped} flag).
 }
 \description{
 Flags variants whose observed z-score is inconsistent with the value
 predicted from its LD neighbours, using susieR's kriging diagnostic.
 \code{susieR::kriging_rss()} computes the leave-one-out conditional
-distribution of each \code{z_i} given the rest, with the LD-mismatch scale
-\code{s} estimated by \code{susieR::estimate_s_rss()}; its standardized
-residual (\code{z_std_diff}) is ~\code{N(0,1)} when z-scores and LD agree, so
-a large residual marks an allele-flip / LD-mismatch outlier. RSS-only helper,
-opt-in via \code{alleleFlipKriging}; never wired into \code{alleleQc()} /
+distribution of each \code{z_i} given the rest (with the LD-mismatch scale
+\code{s} defaulting to \code{susieR::estimate_s_rss()}) and a per-variant
+\code{logLR} for the allele-switch hypothesis. This helper reuses susieR's
+own allele-switch rule --- \code{logLR > logLRThreshold & abs(z) > zThreshold}
+(the same \code{logLR > 2 & |z| > 2} used in \code{susie_rss_utils}) --- to
+flag variants whose sign should be flipped. RSS-only helper, opt-in via
+\code{alleleFlipKriging}; never wired into \code{alleleQc()} /
 \code{matchRefPanel()}. Requires a susieR that provides \code{kriging_rss()}
 and \code{estimate_s_rss()}.
 }

--- a/tests/testthat/test_sumstatsQc.R
+++ b/tests/testthat/test_sumstatsQc.R
@@ -66,25 +66,34 @@ test_that(".resolveZMismatchQc rejects stale rss_qc and other invalid tokens", {
 # krigingOutlierQc
 # ===========================================================================
 
-test_that("krigingOutlierQc flags an LD-inconsistent variant and spares the rest", {
-  skip_if_not("kriging_rss" %in% getNamespaceExports("susieR"),
-              "installed susieR has no kriging_rss")
-  m <- 6
-  rho <- 0.7
-  R <- matrix(rho, m, m); diag(R) <- 1
+# An allele switch (what the flip rule targets) is an LD-CONSISTENT z with one
+# entry's sign reversed -- not a magnitude outlier. Build z = R %*% b (a single
+# causal SNP) then negate a strongly-tagged neighbour, so susieR's logLR fires.
+.kr_switchScenario <- function() {
+  m <- 10; rho <- 0.9
+  R <- outer(seq_len(m), seq_len(m), function(i, j) rho^abs(i - j))
   ids <- paste0("1:", seq_len(m) * 100, ":A:G")
   rownames(R) <- colnames(R) <- ids
-  z <- rep(3, m)
-  z[3] <- -8                       # strongly inconsistent with its neighbours
-  kr <- krigingOutlierQc(z, R, n = 1000, variantIds = ids)
-  expect_true(kr$outlier[3])
-  expect_false(any(kr$outlier[-3]))
-  expect_equal(nrow(kr$diagnostics), m)
-  expect_true(all(c("predicted", "residual", "statistic", "p_value") %in%
+  b <- numeric(m); b[5] <- 6
+  z <- as.numeric(R %*% b)
+  z[6] <- -z[6]                    # flip a strongly-tagged neighbour of the causal
+  list(z = z, R = R, ids = ids, flipped = 6L)
+}
+
+test_that("krigingOutlierQc flags an allele-switched variant and spares the rest", {
+  skip_if_not("kriging_rss" %in% getNamespaceExports("susieR"),
+              "installed susieR has no kriging_rss")
+  s  <- .kr_switchScenario()
+  kr <- krigingOutlierQc(s$z, s$R, n = 1000, variantIds = s$ids)
+  expect_true(kr$flip[s$flipped])
+  expect_equal(sum(kr$flip), 1L)
+  expect_equal(nrow(kr$diagnostics), length(s$z))
+  expect_true(all(c("z", "condmean", "z_std_diff", "logLR", "flipped") %in%
                     colnames(kr$diagnostics)))
+  expect_identical(kr$diagnostics$flipped, kr$flip)
 })
 
-test_that("krigingOutlierQc statistic matches susieR::kriging_rss z_std_diff", {
+test_that("krigingOutlierQc flip == susieR's logLR>2 & |z|>2 selection", {
   skip_if_not("kriging_rss" %in% getNamespaceExports("susieR"),
               "installed susieR has no kriging_rss")
   set.seed(7); m <- 10
@@ -93,10 +102,28 @@ test_that("krigingOutlierQc statistic matches susieR::kriging_rss z_std_diff", {
   rownames(R) <- colnames(R) <- ids
   z <- as.numeric(R %*% rnorm(m)); z[4] <- 9
   kr  <- krigingOutlierQc(z, R, n = 5000, variantIds = ids)
-  s   <- susieR::estimate_s_rss(z = z, R = R, n = 5000)
-  ref <- susieR::kriging_rss(z = z, R = R, n = 5000, s = s)$conditional_dist
-  expect_equal(kr$diagnostics$statistic, as.numeric(ref$z_std_diff), tolerance = 1e-8)
-  expect_equal(kr$diagnostics$predicted, as.numeric(ref$condmean),   tolerance = 1e-8)
+  ref <- susieR::kriging_rss(z = z, R = R, n = 5000)$conditional_dist
+  # susieR's own allele-switch rule (susie_rss_utils.R): logLR > 2 & |z| > 2.
+  expected <- as.numeric(ref$logLR) > 2 & abs(z) > 2
+  expect_identical(kr$flip, expected)
+  expect_equal(kr$diagnostics$logLR,      as.numeric(ref$logLR),     tolerance = 1e-8)
+  expect_equal(kr$diagnostics$z_std_diff, as.numeric(ref$z_std_diff), tolerance = 1e-8)
+  expect_equal(kr$diagnostics$condmean,   as.numeric(ref$condmean),   tolerance = 1e-8)
+})
+
+test_that("krigingOutlierQc thresholds are configurable", {
+  skip_if_not("kriging_rss" %in% getNamespaceExports("susieR"),
+              "installed susieR has no kriging_rss")
+  s <- .kr_switchScenario()
+  # The switch fires at the default logLRThreshold = 2 ...
+  expect_true(krigingOutlierQc(s$z, s$R, n = 1000,
+                               variantIds = s$ids)$flip[s$flipped])
+  # ... and an impossibly high logLR threshold suppresses every flip.
+  expect_false(any(krigingOutlierQc(s$z, s$R, n = 1000, variantIds = s$ids,
+                                    logLRThreshold = 1e6)$flip))
+  # A |z| threshold above the switched z also suppresses it.
+  expect_false(any(krigingOutlierQc(s$z, s$R, n = 1000, variantIds = s$ids,
+                                    zThreshold = 1e6)$flip))
 })
 
 test_that("krigingOutlierQc requires a positive sample size n", {
@@ -4996,7 +5023,7 @@ test_that("summaryStatsQc: early-exits when fewer than two variants survive pre-
   expect_equal(length(res$entry[[1L]]), 1L)
 })
 
-test_that("summaryStatsQc: kriging prefilter runs, records outliers, and adds the rollup segment", {
+test_that("summaryStatsQc: kriging QC runs, records the flip audit, and adds the rollup segment", {
   skip_if_not("kriging_rss" %in% getNamespaceExports("susieR"),
               "installed susieR has no kriging_rss")
   ss <- GwasSumStats(
@@ -5013,10 +5040,16 @@ test_that("summaryStatsQc: kriging prefilter runs, records outliers, and adds th
     res <- summaryStatsQc(ss, alleleFlipKriging = TRUE, pipCutoffToSkip = 0,
                           nCutoff = 0))
   joined <- paste(msgs, collapse = "")
-  expect_match(joined, "kriging prefilter removed")
-  expect_match(joined, "kriging ")
+  expect_match(joined, "kriging sign-flipped")
+  expect_match(joined, "kriging-flip ")
   ea <- getQcInfo(res)$entryAudit[[1L]]
-  expect_true("krigingOutliersDropped" %in% names(ea))
+  expect_true("krigingFlipped" %in% names(ea))
+  expect_true("krigingDiagnostics" %in% names(ea))
+  kd <- ea$krigingDiagnostics
+  expect_true(is.data.frame(kd))
+  expect_true(all(c("variant_id", "z", "condmean", "z_std_diff", "logLR",
+                    "flipped") %in% colnames(kd)))
+  expect_identical(sum(kd$flipped), ea$krigingFlipped)
 })
 
 test_that("summaryStatsQc: impute = TRUE assembles BETA/SE/N and median-fills missing N", {
@@ -5210,13 +5243,14 @@ test_that("raiss multi-LD-block skips a NULL middle block and keeps the rest (li
   expect_true(all(c("var1", "var21") %in% res$resultNofilter$variant_id))
 })
 
-test_that("summaryStatsQc kriging prefilter drops an LD-inconsistent variant (line 3063)", {
+test_that("summaryStatsQc kriging QC sign-flips an LD-inconsistent variant and retains it", {
   skip_if_not("kriging_rss" %in% getNamespaceExports("susieR"),
               "installed susieR has no kriging_rss")
   # All eight genotype columns load on one common factor (pairwise rho ~0.7),
-  # but rs4 carries a z-score (-15) grossly inconsistent with its strongly
-  # correlated neighbours. krigingOutlierQc flags it, so the prefilter actually
-  # drops a row (sumstatsQc.R:3063, the nKr > 0 branch).
+  # so LD predicts a shared sign. rs4's z has the opposite sign to its strongly
+  # correlated neighbours -- a genuine allele switch. krigingOutlierQc flags it,
+  # so the QC step sign-flips its Z in place (the nKr > 0 branch) and RETAINS
+  # the row.
   corrExtractor <- function(handle, snpIdx, meanImpute = TRUE) {
     set.seed(42)
     n <- length(handle@sampleIds)
@@ -5241,7 +5275,9 @@ test_that("summaryStatsQc kriging prefilter drops an LD-inconsistent variant (li
   gr <- .ssQ_makeEntryGr(snp_ids = paste0("rs", 1:8),
                          positions = seq(100L, by = 100L, length.out = 8L))
   mc <- S4Vectors::mcols(gr)
-  mc$Z <- c(4, 4, 4, -15, 4, 4, 4, 4)
+  # LD-consistent block (all +4) with rs4's sign reversed -- a genuine allele
+  # switch (logLR > 2 & |z| > 2), which the kriging QC sign-flips back to +4.
+  mc$Z <- c(4, 4, 4, -4, 4, 4, 4, 4)
   mc$N <- rep(3000L, 8)
   S4Vectors::mcols(gr) <- mc
   ss <- GwasSumStats(study = "g1", entry = list(gr), genome = "hg19",
@@ -5250,6 +5286,12 @@ test_that("summaryStatsQc kriging prefilter drops an LD-inconsistent variant (li
   res <- suppressWarnings(
     summaryStatsQc(ss, alleleFlipKriging = TRUE, pipCutoffToSkip = 0, nCutoff = 0))
   ea <- getQcInfo(res)$entryAudit[[1L]]
-  expect_gte(ea$krigingOutliersDropped, 1L)             # at least one dropped
-  expect_equal(length(res$entry[[1L]]), 8L - ea$krigingOutliersDropped)
+  expect_gte(ea$krigingFlipped, 1L)                     # at least one flipped
+  expect_equal(length(res$entry[[1L]]), 8L)             # retained, not dropped
+  # rs4's -15 flips to +15; its neighbours were +4, so every retained Z is now
+  # positive.
+  zout <- S4Vectors::mcols(res$entry[[1L]])$Z
+  expect_true(all(zout > 0))
+  # the audit's flip count equals the diagnostics rows marked flipped.
+  expect_identical(sum(ea$krigingDiagnostics$flipped), ea$krigingFlipped)
 })


### PR DESCRIPTION
krigingOutlierQc now uses susieR's allele-switch rule (logLR > 2 & |z| > 2)
and sign-flips the flagged z (and beta) in place, keeping the variants,
rather than dropping on the old z_std_diff p<5e-8 rule. The per-variant
kriging table lands on entryAudit$krigingDiagnostics and the rollup reports
kriging-flip N in the corrected segment. alleleFlipKriging stays off by default.
