### PR TITLE
RSS credible-set labels: true effect index + complete summary

### DIFF
--- a/R/credibleSetSummary.R
+++ b/R/credibleSetSummary.R
@@ -38,32 +38,22 @@ NULL
     mx + log(sum(exp(lv - mx))) - log(length(lv))
 }
 
-# One row per credible set at `coverage`, summarising size, purity (min from the
-# canonical cs_<cov>_purity column, mean from the fit's sets$purity when
-# present),
-# the per-effect prior variance V, the CS log Bayes factor (max member logBF),
-# and the lead (highest-PIP) variant. Sourced primarily from the entry's topLoci
-# so it stays consistent with getCs / getTopLoci; V / mean-purity come from the
-# stored fit. The credible-set index in the `cs` label doubles as the effect (L)
-# index for susie-family fits (unfiltered CS are ordered by effect).
+# One row per credible set at `coverage`. Prefers the fit's own per-coverage
+# credible sets (`susieFit$sets$cs`): sourcing from the fit makes the table
+# COMPLETE -- every set the fit found gets a row, including one whose variants
+# were all relabelled to a smaller overlapping set in the per-variant column --
+# with per-set stats over the true full membership. When the stored fit carries
+# no per-coverage sets (a minimal / hand-built fit), it falls back to
+# enumerating the per-variant cs_<cov> column (the labelled members only). Rows
+# carry the fit's true effect index (cs = <method>_<k>, effect_id = L<k>).
 # @noRd
 .csSummaryFit <- function(tl, fit, coverage) {
-    csCol <- str_c("cs_", coverage * 100)
-    purCol <- str_c(csCol, "_purity")
-    if (is.null(tl) || nrow(tl) == 0L || !is_in(csCol, names(tl))) {
+    specs <- .csSummarySpecs(tl, fit, coverage)
+    if (length(specs) == 0L) {
         return(.emptyCsSummary())
     }
-    csValues <- tl[[csCol]]
-    labels <- unique(csValues[
-        !is.na(csValues) &
-            str_length(csValues) > 0L &
-            !str_detect(csValues, "_0$")
-    ])
-    if (length(labels) == 0L) {
-        return(.emptyCsSummary())
-    }
-    ctx <- .csSummaryContext(tl, fit, coverage, csCol, purCol)
-    map(labels, .csSummaryRow, ctx = ctx) |>
+    ctx <- list(tl = tl, fit = fit, coverage = coverage)
+    map(specs, .csSummaryRow, ctx = ctx) |>
         bind_rows() |>
         mutate(
             cs_log10bf = if_else(
@@ -74,73 +64,212 @@ NULL
         )
 }
 
-# Per-fit context for the CS summary rows: prior variances (V) and per-effect
-# mean-purity, plus the resolved column names.
+# Per-CS specs (member variant ids, true effect index, purity, method tag) for
+# `coverage`: from the fit's sets$cs when present (complete membership), else
+# from the per-variant cs_<cov> column (the labelled members only).
 # @noRd
-.csSummaryContext <- function(tl, fit, coverage, csCol, purCol) {
-    Vvec <- if (!is.null(fit$V)) as.numeric(fit$V) else NULL
-    meanPur <- NULL
-    sp <- fit$sets$purity
-    if (!is.null(sp)) {
-        mc <- intersect(c("meanAbsCorr", "mean.abs.corr"), names(sp))
-        if (length(mc) > 0L) {
-            meanPur <- set_names(as.numeric(sp[[mc[1L]]]), rownames(sp))
-        }
+.csSummarySpecs <- function(tl, fit, coverage) {
+    setsObj <- .csSetsForCoverage(fit, coverage)
+    if (!is.null(setsObj) && !is.null(setsObj$cs) && length(setsObj$cs) > 0L) {
+        return(.csSpecsFromFit(setsObj, tl, fit, coverage))
     }
-    list(
-        tl = tl,
-        fit = fit,
-        coverage = coverage,
-        csCol = csCol,
-        purCol = purCol,
-        Vvec = Vvec,
-        meanPur = meanPur
-    )
+    .csSpecsFromColumn(tl, fit, coverage)
 }
 
-# One credible-set summary row for label `lab`.
+# Complete per-CS specs sourced from the fit's credible sets. Member positions
+# (setsObj$cs) map to variant ids via the alpha column names; the effect index
+# comes from the sets$cs "L<k>" names; purity is read by set position.
 # @noRd
-.csSummaryRow <- function(lab, ctx) {
-    m <- filter(ctx$tl, .data[[ctx$csCol]] == lab)
-    Lidx <- suppressWarnings(as.integer(str_remove(lab, "^.*_")))
-    Lname <- if (!is.na(Lidx)) str_c("L", Lidx) else NA_character_
-    lead <- which.max(m$pip)
+.csSpecsFromFit <- function(setsObj, tl, fit, coverage) {
+    vn <- colnames(fit$alpha)
+    eff <- .fmEffectIndices(setsObj$cs)
+    methodTag <- .csMethodTag(tl, fit, coverage)
+    map(seq_along(setsObj$cs), function(k) {
+        members <- as.integer(setsObj$cs[[k]])
+        list(
+            ids = if (!is.null(vn)) vn[members] else NA_character_,
+            n = length(members),
+            eff = eff[k],
+            purity_min = .csPurityAtK(setsObj$purity, k, "min.abs.corr"),
+            purity_mean = .csPurityAtK(
+                setsObj$purity, k, c("mean.abs.corr", "meanAbsCorr")
+            ),
+            methodTag = methodTag
+        )
+    })
+}
+
+# Fallback per-CS specs from the per-variant cs_<cov> column (labelled members
+# only); used when the stored fit carries no per-coverage credible sets.
+# @noRd
+.csSpecsFromColumn <- function(tl, fit, coverage) {
+    csCol <- str_c("cs_", round(coverage * 100))
+    purCol <- str_c(csCol, "_purity")
+    if (is.null(tl) || nrow(tl) == 0L || !is_in(csCol, names(tl))) {
+        return(list())
+    }
+    vals <- tl[[csCol]]
+    labels <- unique(vals[
+        !is.na(vals) & str_length(vals) > 0L & !str_detect(vals, "_0$")
+    ])
+    if (length(labels) == 0L) {
+        return(list())
+    }
+    meanPur <- .csMeanPurLookup(fit)
+    map(labels, function(lab) {
+        m <- tl[!is.na(vals) & vals == lab, , drop = FALSE]
+        eff <- suppressWarnings(as.integer(str_remove(lab, "^.*_")))
+        Lname <- if (!is.na(eff)) str_c("L", eff) else NA_character_
+        list(
+            ids = m$variant_id,
+            n = nrow(m),
+            eff = eff,
+            purity_min = if (is_in(purCol, names(m))) {
+                as.numeric(m[[purCol]][1])
+            } else {
+                NA_real_
+            },
+            purity_mean = if (!is.null(meanPur) && !is.na(Lname) &&
+                is_in(Lname, names(meanPur))) {
+                as.numeric(meanPur[[Lname]])
+            } else {
+                NA_real_
+            },
+            methodTag = str_remove(lab, "_[0-9]+$")
+        )
+    })
+}
+
+# The credible-set object (sets$cs + sets$purity) for `coverage`: the fit's
+# primary `sets` when it matches the fit's requested coverage, else the stored
+# secondary set for that coverage (`fit$sets_secondary`, named
+# "CS_<cov*100>_<method>"). NULL when that coverage was not computed / stored.
+# @noRd
+.csSetsForCoverage <- function(fit, coverage) {
+    pc <- fit$sets$requested_coverage
+    if (!is.null(pc) &&
+        isTRUE(all.equal(as.numeric(pc[1L]), as.numeric(coverage)))) {
+        return(fit$sets)
+    }
+    sec <- fit$sets_secondary
+    if (!is.null(sec) && length(sec) > 0L) {
+        nums <- suppressWarnings(
+            as.integer(str_match(names(sec), "(?i)cs_(\\d+)_")[, 2L])
+        )
+        h <- which(nums == round(coverage * 100))
+        if (length(h) > 0L) {
+            return(sec[[h[1L]]]$sets)
+        }
+    }
+    # Untrimmed fit with no secondary store and no recorded coverage: the
+    # primary sets are the only ones present -- use them.
+    if ((is.null(sec) || length(sec) == 0L) &&
+        is.null(pc) && !is.null(fit$sets$cs)) {
+        return(fit$sets)
+    }
+    NULL
+}
+
+# The method tag for the cs label: prefer the tag already in the entry's
+# cs_<cov> column (keeps the summary consistent with the per-variant labels);
+# fall back to the fit's class when the column carries no CS label.
+# @noRd
+.csMethodTag <- function(tl, fit, coverage) {
+    csCol <- str_c("cs_", round(coverage * 100))
+    if (!is.null(tl) && is_in(csCol, names(tl))) {
+        v <- tl[[csCol]]
+        v <- v[!is.na(v) & str_length(v) > 0L & !str_detect(v, "_0$")]
+        if (length(v) > 0L) {
+            return(str_remove(v[1L], "_[0-9]+$"))
+        }
+    }
+    .camelToSnakeMethod(class(fit)[1L])
+}
+
+# Per-effect mean-abs-corr lookup (named by L<k>) from the fit's sets$purity.
+# @noRd
+.csMeanPurLookup <- function(fit) {
+    sp <- fit$sets$purity
+    if (is.null(sp)) {
+        return(NULL)
+    }
+    mc <- intersect(c("meanAbsCorr", "mean.abs.corr"), names(sp))
+    if (length(mc) == 0L) {
+        return(NULL)
+    }
+    set_names(as.numeric(sp[[mc[1L]]]), rownames(sp))
+}
+
+# One summary row from a per-CS spec. Size / effect index / purity / method tag
+# come from the spec; member statistics (pip, member logBF, conditional effect,
+# lead) from the entry topLoci; prior variance / per-effect logBF from the fit.
+# @noRd
+.csSummaryRow <- function(spec, ctx) {
+    m <- .csMemberRows(ctx$tl, spec$ids)
+    pipVec <- if (!is.null(m) && is_in("pip", names(m))) {
+        as.numeric(m$pip)
+    } else {
+        NULL
+    }
+    lead <- if (!is.null(pipVec) && any(is.finite(pipVec))) {
+        which.max(pipVec)
+    } else {
+        integer(0)
+    }
+    eff <- spec$eff
     tibble(
-        cs = lab,
-        effect_id = Lname,
+        cs = str_c(spec$methodTag, "_", eff),
+        effect_id = if (!is.na(eff)) str_c("L", eff) else NA_character_,
         coverage = ctx$coverage,
-        n_variants = nrow(m),
-        purity_min = .csPurityMin(m, ctx$purCol),
-        purity_mean = .csPurityMean(ctx$meanPur, Lname),
-        V = .csEffectV(ctx$Vvec, Lidx),
+        n_variants = spec$n,
+        purity_min = spec$purity_min,
+        purity_mean = spec$purity_mean,
+        # V: the effect's prior variance, keyed by true effect index.
+        V = .csEffectV(if (!is.null(ctx$fit$V)) as.numeric(ctx$fit$V) else NULL, eff),
         # cs_log10bf: the strongest MEMBER variant's logBF (max over the CS).
         cs_log10bf = .csLog10Bf(m),
         # cs_log_bf: the true per-EFFECT single-effect log Bayes factor.
-        cs_log_bf = .csEffectLogBf(ctx$fit, Lidx),
+        cs_log_bf = .csEffectLogBf(ctx$fit, eff),
         # cs_pip: total posterior inclusion mass captured by the CS.
-        cs_pip = suppressWarnings(sum(as.numeric(m$pip), na.rm = TRUE)),
+        cs_pip = if (!is.null(pipVec)) {
+            suppressWarnings(sum(pipVec, na.rm = TRUE))
+        } else {
+            NA_real_
+        },
         # cs_mean_effect: mean posterior conditional effect over the CS (NA when
         # the entry has no conditional_effect column, e.g. univariate susie).
         cs_mean_effect = .csMeanEffect(m),
-        lead_variant = as.character(m$variant_id[lead]),
-        lead_pip = as.numeric(m$pip[lead])
+        lead_variant = if (length(lead) > 0L) {
+            as.character(m$variant_id[lead])
+        } else {
+            NA_character_
+        },
+        lead_pip = if (length(lead) > 0L) as.numeric(pipVec[lead]) else NA_real_
     )
 }
 
-# purity_min: first per-CS purity value (NA when the column is absent).
+# The entry-topLoci rows for the given member variant ids, matched by
+# variant_id (robust to any PIP filtering / reordering of the table). NULL when
+# the table lacks a variant_id column.
 # @noRd
-.csPurityMin <- function(m, purCol) {
-    if (is_in(purCol, names(m))) as.numeric(m[[purCol]][1]) else NA_real_
+.csMemberRows <- function(tl, ids) {
+    if (is.null(tl) || !is_in("variant_id", names(tl)) || all(is.na(ids))) {
+        return(NULL)
+    }
+    tl[match(ids, tl$variant_id), , drop = FALSE]
 }
 
-# purity_mean: per-effect mean absolute correlation (NA when unavailable).
+# Per-set purity at set POSITION k, first available of `cols` (NA when absent).
 # @noRd
-.csPurityMean <- function(meanPur, Lname) {
-    if (!is.null(meanPur) && !is.na(Lname) && is_in(Lname, names(meanPur))) {
-        as.numeric(meanPur[[Lname]])
-    } else {
-        NA_real_
+.csPurityAtK <- function(purity, k, cols) {
+    if (is.null(purity)) {
+        return(NA_real_)
     }
+    nm <- intersect(cols, colnames(purity))
+    if (length(nm) == 0L || k > nrow(purity)) {
+        return(NA_real_)
+    }
+    as.numeric(purity[[nm[1L]]][k])
 }
 
 # V: the effect's prior variance (NA when out of range / unavailable).

--- a/R/fineMappingWrappers.R
+++ b/R/fineMappingWrappers.R
@@ -1085,7 +1085,8 @@ setMethod(
 # Per-variant CS index at coverage `targetCov` (0 = not in any CS; on overlap
 # the smallest cs_idx wins).
 # @noRd
-.fmCsIdxAtCoverage <- function(targetCov, coverageValues, csTables, nV) {
+.fmCsIdxAtCoverage <- function(targetCov, coverageValues, csTables, nV,
+                               variantNames = NULL) {
     out <- integer(nV)
     hit <- which(abs(coverageValues - targetCov) < 1e-12)
     if (length(hit) == 0L) {
@@ -1095,11 +1096,82 @@ setMethod(
     if (is.null(sets) || length(sets) == 0L) {
         return(out)
     }
+    setSizes <- lengths(sets)
+    effIdx <- .fmEffectIndices(sets)
+    # For each variant keep the SMALLEST containing set (ties -> lowest
+    # position, deterministic); record every membership so multi-CS variants
+    # can be warned about. `out` holds set POSITIONS (the purity vector and the
+    # full-fit block index by position); .fmEffectIdxAtCoverage maps these to
+    # the fit's true effect index for the cs_<cov> labels.
+    bestSize <- rep(Inf, nV)
+    memb <- vector("list", nV)
     for (csIdx in seq_along(sets)) {
         vi <- as.integer(sets[[csIdx]])
-        vi <- vi[vi >= 1L & vi <= nV & out[vi] == 0L]
-        out[vi] <- csIdx
+        vi <- vi[vi >= 1L & vi <= nV]
+        for (v in vi) {
+            memb[[v]] <- c(memb[[v]], csIdx)
+            if (setSizes[csIdx] < bestSize[v]) {
+                out[v] <- csIdx
+                bestSize[v] <- setSizes[csIdx]
+            }
+        }
     }
+    for (v in which(lengths(memb) > 1L)) {
+        ps <- memb[[v]]
+        vname <- if (!is.null(variantNames) && v <= length(variantNames)) {
+            variantNames[v]
+        } else {
+            str_c("#", v)
+        }
+        warning(sprintf(
+            paste0(
+                "Variant %s is in multiple credible sets: %s. ",
+                "Keeping the smallest: CS L%d (size %d)."
+            ),
+            vname,
+            str_c("L", effIdx[ps], collapse = ", "),
+            effIdx[out[v]],
+            bestSize[v]
+        ), call. = FALSE)
+    }
+    out
+}
+
+# The fit's true credible-set effect index (the k behind "L<k>") for each set
+# POSITION in `sets$cs`; falls back to the position when the names are absent
+# or unparseable. This is what the cs_<cov> label and the per-set summary carry
+# so a gapped effect index (e.g. L1, L2, L4) is preserved instead of being
+# renumbered 1..n.
+# @noRd
+.fmEffectIndices <- function(sets) {
+    nm <- names(sets)
+    if (is.null(nm)) {
+        return(seq_along(sets))
+    }
+    e <- suppressWarnings(as.integer(str_remove(nm, "^L")))
+    bad <- is.na(e)
+    if (any(bad)) {
+        e[bad] <- seq_along(sets)[bad]
+    }
+    e
+}
+
+# Map a per-variant set-POSITION vector (from .fmCsIdxAtCoverage) to the fit's
+# true effect indices; non-CS entries (0) stay 0.
+# @noRd
+.fmEffectIdxAtCoverage <- function(targetCov, posVec, coverageValues, csTables) {
+    hit <- which(abs(coverageValues - targetCov) < 1e-12)
+    if (length(hit) == 0L) {
+        return(posVec)
+    }
+    sets <- csTables[[hit[1L]]]$sets$cs
+    if (is.null(sets) || length(sets) == 0L) {
+        return(posVec)
+    }
+    effIdx <- .fmEffectIndices(sets)
+    out <- integer(length(posVec))
+    nz <- posVec > 0L
+    out[nz] <- effIdx[posVec[nz]]
     out
 }
 
@@ -1206,7 +1278,7 @@ buildTopLoci <- function(
     fc <- .btlFitConstants(p$dataY, p$otherQuantities, p$region)
     post <- .btlPosterior(p$fit, p$conditionIdx, nV)
     marg <- .btlMarginal(p$sumstats, nV)
-    cs <- .btlCsMembership(cov, p$csTables, nV)
+    cs <- .btlCsMembership(cov, p$csTables, nV, p$variantNames)
     fullFitBlock <- .btlFullFitBlock(
         p$fit,
         post,
@@ -1398,7 +1470,7 @@ buildTopLoci <- function(
 
 # CS membership index + purity for every coverage present (high -> low), with
 # the matching `cs_<coverage*100>` column names.
-.btlCsMembership <- function(coverageValues, csTables, nV) {
+.btlCsMembership <- function(coverageValues, csTables, nV, variantNames = NULL) {
     covSorted <- sort(
         unique(coverageValues[is.finite(coverageValues)]),
         decreasing = TRUE
@@ -1408,7 +1480,18 @@ buildTopLoci <- function(
         .fmCsIdxAtCoverage,
         coverageValues,
         csTables,
-        nV
+        nV,
+        variantNames
+    )
+    # Effect-index view of the same assignment: the cs_<cov> LABEL uses the
+    # fit's true (possibly gapped) effect index, while purity / full-fit keep
+    # indexing by set position via csIdxByCov.
+    csEffectByCov <- map2(
+        covSorted,
+        csIdxByCov,
+        .fmEffectIdxAtCoverage,
+        coverageValues = coverageValues,
+        csTables = csTables
     )
     csPurityByCov <- map2(
         covSorted,
@@ -1420,6 +1503,7 @@ buildTopLoci <- function(
     list(
         covSorted = covSorted,
         csIdxByCov = csIdxByCov,
+        csEffectByCov = csEffectByCov,
         csPurityByCov = csPurityByCov,
         csColNames = str_c("cs_", covSorted * 100)
     )
@@ -1526,7 +1610,7 @@ buildTopLoci <- function(
     methodTag <- .camelToSnakeMethod(method)
     csList <- c(
         set_names(
-            map(cs$csIdxByCov, .btlCsLabel, methodTag = methodTag),
+            map(cs$csEffectByCov, .btlCsLabel, methodTag = methodTag),
             cs$csColNames
         ),
         set_names(cs$csPurityByCov, str_c(cs$csColNames, "_purity"))

--- a/tests/testthat/test_credibleSetSummary.R
+++ b/tests/testthat/test_credibleSetSummary.R
@@ -168,3 +168,87 @@ test_that("getCredibleSetSummary aggregates across a collection with entry ident
     expect_equal(nrow(s), 2L) # one CS per entry
     expect_setequal(unique(s$context), c("brain", "blood"))
 })
+
+test_that("getCredibleSetSummary lists every fit CS, even one dropped from the per-variant column", {
+    # When the fit carries sets$cs the summary is built from it, so a set whose
+    # members were all relabelled to a smaller overlapping set in the
+    # per-variant column still gets a row -- with its true full size.
+    vn <- paste0("chr1:", (1:5) * 100, ":A:G")
+    alpha <- matrix(0, 2, 5, dimnames = list(c("L1", "L2"), vn))
+    alpha[1, 1:3] <- 0.3
+    alpha[2, 2] <- 0.9
+    fit <- list(
+        pip = c(0.3, 0.9, 0.3, 0.01, 0.01),
+        alpha = alpha,
+        V = c(0.1, 0.2),
+        lbf_variable = matrix(
+            c(1, 1, 1, 0, 0, 0, 2, 0, 0, 0),
+            2, 5,
+            byrow = TRUE, dimnames = list(c("L1", "L2"), vn)
+        ),
+        sets = list(
+            # L2 = {2} is contained in L1 = {1,2,3}: v2 tags to the smaller L2
+            # in the per-variant column, so L1 loses it there.
+            cs = list(L1 = c(1L, 2L, 3L), L2 = c(2L)),
+            purity = data.frame(
+                min.abs.corr = c(0.8, 1.0),
+                mean.abs.corr = c(0.85, 1.0),
+                row.names = c("L1", "L2")
+            ),
+            requested_coverage = 0.95
+        )
+    )
+    class(fit) <- "susie"
+    tl <- data.frame(
+        variant_id = vn,
+        pip = fit$pip,
+        logBF = c(1, 2, 1, 0, 0),
+        cs_95 = c("susie_1", "susie_2", "susie_1", "susie_0", "susie_0"),
+        cs_95_purity = c(0.8, 1.0, 0.8, 0, 0),
+        stringsAsFactors = FALSE
+    )
+    e <- FineMappingEntry(variantIds = vn, susieFit = fit, topLoci = tl)
+    s <- getCredibleSetSummary(e, coverage = 0.95)
+    s <- s[order(s$effect_id), , drop = FALSE]
+    expect_equal(nrow(s), 2L) # == length(fit$sets$cs), no set dropped
+    expect_equal(s$cs, c("susie_1", "susie_2"))
+    expect_equal(s$effect_id, c("L1", "L2"))
+    # L1 keeps its full size 3 even though only v1/v3 carry its per-variant tag
+    expect_equal(s$n_variants, c(3L, 1L))
+    expect_equal(s$purity_min, c(0.8, 1.0))
+    # cs_pip summed over the TRUE membership (includes v2 for L1)
+    expect_equal(s$cs_pip, c(1.5, 0.9), tolerance = 1e-9)
+    expect_equal(s$lead_variant, c("chr1:200:A:G", "chr1:200:A:G"))
+})
+
+test_that("getCredibleSetSummary labels by the fit's true (gapped) effect index", {
+    # sets$cs is ordered L2, L1 (e.g. by purity): the row for the size-3 set
+    # must be effect_id L2 / susie_2, not renumbered to position 1.
+    vn <- paste0("chr1:", (1:4) * 100, ":A:G")
+    alpha <- matrix(0, 2, 4, dimnames = list(c("L2", "L1"), vn))
+    fit <- list(
+        pip = c(0.3, 0.3, 0.3, 0.6),
+        alpha = alpha,
+        V = c(0.1, 0.2),
+        sets = list(
+            cs = list(L2 = c(1L, 2L, 3L), L1 = c(4L)),
+            purity = data.frame(
+                min.abs.corr = c(0.9, 0.5),
+                row.names = c("L2", "L1")
+            ),
+            requested_coverage = 0.95
+        )
+    )
+    class(fit) <- "susie"
+    tl <- data.frame(
+        variant_id = vn, pip = fit$pip, logBF = c(1, 1, 1, 2),
+        cs_95 = c("susie_2", "susie_2", "susie_2", "susie_1"),
+        stringsAsFactors = FALSE
+    )
+    e <- FineMappingEntry(variantIds = vn, susieFit = fit, topLoci = tl)
+    s <- getCredibleSetSummary(e, coverage = 0.95)
+    big <- s[s$n_variants == 3L, , drop = FALSE]
+    expect_equal(big$effect_id, "L2") # the size-3 set is L2, not L1
+    expect_equal(big$cs, "susie_2")
+    expect_equal(big$purity_min, 0.9)
+})

--- a/tests/testthat/test_fineMappingWrappers.R
+++ b/tests/testthat/test_fineMappingWrappers.R
@@ -2987,3 +2987,39 @@ test_that("computeCsCorrelation (QtlDataset) matches the sumstat path", {
     expect_equal(dim(ccGeno), c(2L, 2L))
     expect_equal(unname(ccGeno), unname(ccSketch), tolerance = 1e-6)
 })
+
+test_that(".fmCsIdxAtCoverage: multi-CS variant takes the smallest set and warns", {
+    # v2 is in L1 (size 5) and L4 (size 1); L2 = {6,7}. Gapped index (no L3).
+    sets <- list(L1 = 1:5, L2 = 6:7, L4 = 2L)
+    csTables <- list(list(sets = list(cs = sets)))
+    cov <- 0.95
+    nV <- 10L
+    vn <- paste0("v", seq_len(nV))
+    expect_warning(
+        pos <- .fmCsIdxAtCoverage(cov, cov, csTables, nV, vn),
+        "multiple credible sets"
+    )
+    eff <- .fmEffectIdxAtCoverage(cov, pos, cov, csTables)
+    # smallest-set tie-break: v2 kept L4 (size 1), whose position is 3
+    expect_equal(pos[2], 3L)
+    # label is the TRUE effect index (4, gapped), not the renumbered position 3
+    expect_equal(eff[2], 4L)
+    # single-membership + non-CS variants unchanged
+    expect_equal(eff[1], 1L) # only in L1
+    expect_equal(eff[6], 2L) # only in L2
+    expect_equal(eff[8], 0L) # in no set
+})
+
+test_that(".fmCsIdxAtCoverage: no warning and no relabelling when sets are disjoint", {
+    sets <- list(L1 = 1:3, L2 = 4:5)
+    csTables <- list(list(sets = list(cs = sets)))
+    vn <- paste0("v", 1:6)
+    expect_silent(pos <- .fmCsIdxAtCoverage(0.95, 0.95, csTables, 6L, vn))
+    eff <- .fmEffectIdxAtCoverage(0.95, pos, 0.95, csTables)
+    expect_equal(eff, c(1L, 1L, 1L, 2L, 2L, 0L))
+})
+
+test_that(".fmEffectIndices: parses L-names, falls back to position when absent", {
+    expect_equal(.fmEffectIndices(list(L1 = 1, L2 = 2, L7 = 3)), c(1L, 2L, 7L))
+    expect_equal(.fmEffectIndices(list(1, 2, 3)), c(1L, 2L, 3L)) # unnamed -> position
+})


### PR DESCRIPTION
Restores the 2025 `get_cs_index` semantics for credible-set labelling and makes the per-CS summary complete.

- **Multi-CS variant**: takes the smallest containing set (by size) with a warning naming the variant and competing sets, instead of silently taking the lowest list position.
- **Labels**: `cs_<cov>` carries the fit's true effect index (`susie_rss_10`), not a position renumbered from 1 — a gapped index (L1, L2, L4) survives. Numeric format keeps the trailing-number parsers working.
- **getCredibleSetSummary**: rebuilt from `susieFit$sets$cs` — one row per real credible set (none dropped when its members relabel to a smaller overlapping set), per-set stats over the true full membership. Falls back to the per-variant column only for minimal fits with no `sets$cs`.

Accessor-only: the fitted RDS, PIP, and effect values are unchanged.

Validated on real chr21 `median05.rds` (a 2-CS block the fit orders L2, L1): the size-29 set is now labelled L2 to match the fit, where the old code mislabelled it L1. New unit tests cover the smallest-set tie-break + warning, the gapped effect index, and summary completeness; `test_credibleSetSummary` 31/0, `test_fineMappingWrappers` 460/0, `test_fineMappingPipeline` 475/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
