### PR TITLE
RSS af/MAF: declared-only af, directionless maf QC-only

### DIFF
--- a/R/fineMappingPipeline.R
+++ b/R/fineMappingPipeline.R
@@ -793,15 +793,17 @@ setGeneric("fineMappingPipeline", function(data, ...) {
     list(study = study, method = method, region = region, entry = entry)
 }
 
-# Effect-allele frequency vector aligned to `variantIds` from an entry's MAF
-# mcol (post-QC harmonized/complemented). NULL when the entry carries no MAF.
+# Effect-allele frequency vector aligned to `variantIds` from an entry's
+# DIRECTIONAL AF mcol (post-QC harmonized/complemented to the final effect
+# allele). NULL when the entry carries no declared af -- a directionless MAF is
+# NOT used here (it is QC-only), so undeclared-af entries export af = NA.
 # @noRd
 .fmAfByVar <- function(entry, variantIds) {
     mc <- S4Vectors::mcols(entry)
-    if (!is_in("MAF", colnames(mc))) {
+    if (!is_in("AF", colnames(mc))) {
         return(NULL)
     }
-    set_names(as.numeric(mc$MAF), as.character(mc$SNP))[variantIds]
+    set_names(as.numeric(mc$AF), as.character(mc$SNP))[variantIds]
 }
 
 # Region label derived from a GwasSumStats entry's GRanges, so multi-block

--- a/R/manifestLoaders.R
+++ b/R/manifestLoaders.R
@@ -516,6 +516,14 @@ NULL
     BETA = c("beta", "BETA"),
     SE = c("se", "SE"),
     P = c("p", "P", "pvalue", "pval"),
+    # AF: the DIRECTIONAL effect-allele frequency, exported as top_loci$af.
+    # Declared only via an explicit `af`/`AF` mapping key (or a source column
+    # literally named `af`); a source named effect_allele_frequency is NOT
+    # auto-trusted as directional -- it must be mapped `af: <col>`.
+    AF = c("af"),
+    # MAF: a DIRECTIONLESS minor-allele frequency, internal QC only (never
+    # exported as af). effect_allele_frequency stays here so an unmapped such
+    # column is used for filtering but not treated as directional af.
     MAF = c("maf", "MAF", "effect_allele_frequency"),
     INFO = c("info", "INFO")
 )
@@ -536,6 +544,8 @@ NULL
     BETA = c("beta", "BETA"),
     SE = c("se", "SE"),
     P = c("p", "P", "pvalue"),
+    # `af:` (directional effect-allele freq) vs `maf:` (directionless, QC only).
+    AF = c("af", "AF"),
     MAF = c("maf", "MAF", "effect_allele_frequency"),
     INFO = c("info", "INFO")
 )
@@ -587,7 +597,7 @@ NULL
 # column
 # aliases; NA when unresolved.
 # @noRd
-.resolveSumstatKey <- function(key, df, mapping, label) {
+.resolveSumstatKey <- function(key, df, mapping, label, claimed = character()) {
     # Look the field up in the mapping under any accepted standard-key spelling
     # (`z`/`Z`, `n_sample`/`N`, ...). `intersect` avoids the "subscript out of
     # bounds" a named character vector throws for an absent `[[` key.
@@ -605,7 +615,11 @@ NULL
             return(src)
         }
     }
-    intersect(.sumstatColumnAliases[[key]], names(df))[1L]
+    # Auto-detect: never steal a source column another key explicitly claimed
+    # (so `af: effect_allele_frequency` is not also auto-read as MAF).
+    intersect(
+        .sumstatColumnAliases[[key]], setdiff(names(df), claimed)
+    )[1L]
 }
 
 # Standardise the columns of a raw sumstats data.frame into the canonical
@@ -726,11 +740,40 @@ NULL
         out$N_CASE <- as.numeric(df[[n$ncaseSrc]])
         out$N_CONTROL <- as.numeric(df[[n$ncontrolSrc]])
     }
-    for (key in c("BETA", "SE", "P", "MAF", "INFO")) {
-        src <- .resolveSumstatKey(key, df, mapping, label)
+    # AF is the directional effect-allele frequency (exported as top_loci$af);
+    # MAF is a directionless QC frequency. Both are optional; resolved here from
+    # their respective keys so a study can declare either, both, or neither.
+    # `claimed` = the source columns named by explicit mappings, so an
+    # auto-detected key never re-reads a column another key already claimed.
+    claimed <- if (!is.null(mapping)) unname(as.character(mapping)) else character()
+    afSrc <- .resolveSumstatKey("AF", df, mapping, label, claimed)
+    for (key in c("BETA", "SE", "P", "AF", "MAF", "INFO")) {
+        src <- .resolveSumstatKey(key, df, mapping, label, claimed)
         if (!is.na(src) && !is.null(src)) {
             out[[key]] <- as.numeric(df[[src]])
         }
+    }
+    # Effect-allele-frequency provenance warnings (distinct cases), so an
+    # exported af of NA is never silent:
+    #   - undeclared: no `af:`/`af` source -> af will be NA (the study must
+    #     declare `af:` to get a directional frequency; a directionless maf is
+    #     QC-only).
+    #   - declared-but-missing: an `af:` was declared but its values are all
+    #     unusable -> af will be NA (a data problem, distinct message).
+    afUndeclared <- is.na(afSrc) || is.null(afSrc)
+    if (afUndeclared) {
+        warning(
+            label, ": no effect-allele frequency declared (map `af: <col>` to ",
+            "export a directional af); top_loci$af will be NA. A directionless ",
+            "`maf`/`FRQ` is used for QC only, never as af.",
+            call. = FALSE
+        )
+    } else if (all(is.na(out$AF))) {
+        warning(
+            label, ": effect-allele frequency `af` was declared but its values ",
+            "are all missing/unusable; top_loci$af will be NA.",
+            call. = FALSE
+        )
     }
     out
 }

--- a/R/sumstatsQc.R
+++ b/R/sumstatsQc.R
@@ -2782,7 +2782,9 @@ krigingOutlierQc <- function(
         df$SNP <- df$variant_id
     }
     baseCols <- c("SNP", "A1", "A2", "Z", "N")
-    optCols <- c("MAF", "INFO", "BETA", "SE", "P", "N_CASE", "N_CONTROL")
+    # AF = directional effect-allele frequency (exported as af); MAF =
+    # directionless QC frequency. Both carried when the loader resolved them.
+    optCols <- c("AF", "MAF", "INFO", "BETA", "SE", "P", "N_CASE", "N_CONTROL")
     use <- intersect(c(baseCols, optCols), colnames(df))
     S4Vectors::mcols(gr) <- S4Vectors::DataFrame(select(df, all_of(use)))
     gr
@@ -3059,7 +3061,10 @@ krigingOutlierQc <- function(
         )
         abort(msg)
     }
-    colToComplement <- intersect("MAF", colnames(df))
+    # Complement the DIRECTIONAL af on an allele swap (af -> 1 - af). The
+    # directionless MAF (min(af, 1-af)) is swap-invariant and MUST NOT be
+    # complemented.
+    colToComplement <- intersect("AF", colnames(df))
     if (!is_in("A1", colnames(df)) || !is_in("A2", colnames(df))) {
         abort("summaryStatsQc: input entry must contain A1 and A2 columns.")
     }
@@ -3093,23 +3098,28 @@ krigingOutlierQc <- function(
 #             deviations from the median (a 5-MAD-from-median cap on
 #             per-variant N). Set nCutoff = 0 to disable. Rows with NA N
 #             are always dropped.
-# MAF/FRQ frequency filter (frequency normalised to minor-allele frequency).
+# MAF filter, on the minor-allele frequency min(af, 1-af). The filtering
+# frequency is derived from the directional AF when available (single source of
+# truth); a directionless MAF/FRQ is a fallback only. When no frequency is
+# available the filter is SKIPPED with one warning (it does not abort), so a
+# frequency-less study can still run under a default mafCutoff.
 .cfMaf <- function(df, mafCutoff) {
     if (mafCutoff <= 0) {
         return(list(df = df, dropped = NULL))
     }
-    mafCol <- intersect(c("MAF", "FRQ"), colnames(df))[1L]
-    if (is.na(mafCol)) {
-        msg <- glue(
-            ".applyContentFilters: mafCutoff > 0 requires a MAF or FRQ ",
-            "column."
+    freqCol <- intersect(c("AF", "MAF", "FRQ"), colnames(df))[1L]
+    if (is.na(freqCol)) {
+        warning(
+            "summaryStatsQc: mafCutoff > 0 but no af/MAF/FRQ frequency is ",
+            "available; skipping the MAF filter.",
+            call. = FALSE
         )
-        abort(msg)
+        return(list(df = df, dropped = NULL))
     }
     before <- nrow(df)
-    mafVals <- as.numeric(df[[mafCol]])
-    # Normalise effect-allele frequency to MAF: take min(af, 1-af).
-    mafVals <- pmin(mafVals, 1 - mafVals, na.rm = FALSE)
+    freqVals <- as.numeric(df[[freqCol]])
+    # Minor-allele frequency: min(af, 1-af), direction-agnostic.
+    mafVals <- pmin(freqVals, 1 - freqVals, na.rm = FALSE)
     df <- filter(df, !is.na(mafVals) & mafVals >= mafCutoff)
     list(df = df, dropped = before - nrow(df))
 }
@@ -4420,13 +4430,9 @@ krigingOutlierQc <- function(
     }
     for (i in seq_len(nrow(sumstats))) {
         cols <- colnames(S4Vectors::mcols(sumstats$entry[[i]]))
-        if (mafCutoff > 0 && !any(is_in(c("MAF", "FRQ"), cols))) {
-            msg <- glue(
-                "summaryStatsQc: mafCutoff > 0 requires every entry to ",
-                "carry a MAF or FRQ column; entry {i} does not."
-            )
-            abort(msg)
-        }
+        # mafCutoff no longer pre-aborts on a missing frequency: .cfMaf derives
+        # the MAF from the directional AF (or a fallback MAF/FRQ) and skips with
+        # one warning when none is available.
         if (infoCutoff > 0 && !is_in("INFO", cols)) {
             msg <- glue(
                 "summaryStatsQc: infoCutoff > 0 requires every entry to ",

--- a/tests/testthat/test_sumstatsQc.R
+++ b/tests/testthat/test_sumstatsQc.R
@@ -3135,9 +3135,13 @@ test_that("summaryStatsQc: rejects non-SumStats input", {
     )
 })
 
-test_that("summaryStatsQc: mafCutoff > 0 with no MAF/FRQ column errors", {
+test_that("summaryStatsQc: mafCutoff > 0 with no frequency skips with a warning (no abort)", {
     ss <- .ssQ_makeGwasSumStats()
-    expect_error(summaryStatsQc(ss, mafCutoff = 0.05), "MAF or FRQ column")
+    expect_warning(
+        res <- summaryStatsQc(ss, mafCutoff = 0.05),
+        "skipping the MAF filter"
+    )
+    expect_s4_class(res, "GwasSumStats")
 })
 
 test_that("summaryStatsQc: infoCutoff > 0 with no INFO column errors", {
@@ -6634,12 +6638,13 @@ test_that(".applyContentFilters: FRQ is normalized to MAF via min(af, 1 - af)", 
     expect_equal(out$audit$mafDropped, 2L)
 })
 
-test_that(".applyContentFilters: mafCutoff > 0 without MAF/FRQ column errors", {
+test_that(".applyContentFilters: mafCutoff > 0 without a frequency skips with a warning", {
     df <- data.frame(SNP = paste0("rs", 1:3), stringsAsFactors = FALSE)
-    expect_error(
-        pecotmr:::.applyContentFilters(df, mafCutoff = 0.01),
-        "requires a MAF or FRQ column"
+    expect_warning(
+        out <- pecotmr:::.applyContentFilters(df, mafCutoff = 0.01),
+        "skipping the MAF filter"
     )
+    expect_equal(nrow(out$df), 3L)
 })
 
 test_that(".applyContentFilters: INFO filter drops low-INFO variants", {
@@ -7289,4 +7294,80 @@ test_that(".subsetSketchToIds keeps exactly the entries' variants", {
 test_that(".subsetSketchToRange / .subsetSketchToIds are NULL-safe", {
     expect_null(pecotmr:::.subsetSketchToRange(NULL, list()))
     expect_null(pecotmr:::.subsetSketchToIds(NULL, list()))
+})
+
+# ===========================================================================
+# af / MAF semantics (rss-af-maf-semantics): af is the DIRECTIONAL effect-allele
+# frequency (exported), declared only via an `af:` key; a directionless maf is
+# QC-only, never exported as af.
+# ===========================================================================
+.afm_df <- function(freqcol, val) {
+    d <- data.frame(chrom = "chr1", pos = 100L, variant_id = "chr1:100:A:G",
+                    A1 = "A", A2 = "G", z = 2.5, n_sample = 1000,
+                    stringsAsFactors = FALSE)
+    d[[freqcol]] <- val
+    d
+}
+.afm_cm <- function(...) c(chrom = "chrom", pos = "pos", variant_id = "variant_id",
+                           A1 = "A1", A2 = "A2", z = "z", n_sample = "n_sample", ...)
+
+test_that("resolver: af: key -> directional AF; maf: key -> directionless MAF", {
+    a <- suppressWarnings(pecotmr:::.resolveSumstatCols(
+        .afm_df("effect_allele_frequency", 0.8),
+        .afm_cm(af = "effect_allele_frequency"), "af"))
+    expect_equal(a$AF, 0.8)
+    expect_null(a$MAF)
+    b <- suppressWarnings(pecotmr:::.resolveSumstatCols(
+        .afm_df("effect_allele_frequency", 0.8),
+        .afm_cm(maf = "effect_allele_frequency"), "maf"))
+    expect_null(b$AF)
+    expect_equal(b$MAF, 0.8)
+})
+
+test_that("resolver: undeclared af warns distinctly and yields no AF", {
+    expect_warning(
+        out <- pecotmr:::.resolveSumstatCols(.afm_df("maf", 0.2),
+            .afm_cm(maf = "maf"), "undeclared"),
+        "no effect-allele frequency declared")
+    expect_null(out$AF)
+})
+
+test_that("resolver: declared-but-missing af warns with a distinct message", {
+    expect_warning(
+        pecotmr:::.resolveSumstatCols(.afm_df("eaf", NA_real_),
+            .afm_cm(af = "eaf"), "missing"),
+        "declared but its values are all missing")
+})
+
+test_that(".fmAfByVar reads the directional AF mcol; NULL when af is undeclared", {
+    gA <- pecotmr:::.dfToEntryGranges(suppressWarnings(pecotmr:::.resolveSumstatCols(
+        .afm_df("effect_allele_frequency", 0.8),
+        .afm_cm(af = "effect_allele_frequency"), "af")))
+    expect_equal(unname(pecotmr:::.fmAfByVar(gA, "chr1:100:A:G")), 0.8)
+    gM <- pecotmr:::.dfToEntryGranges(suppressWarnings(pecotmr:::.resolveSumstatCols(
+        .afm_df("effect_allele_frequency", 0.8),
+        .afm_cm(maf = "effect_allele_frequency"), "maf")))
+    expect_null(pecotmr:::.fmAfByVar(gM, "chr1:100:A:G"))
+})
+
+test_that(".cfMaf derives from af, falls back to maf, and skips-with-warning", {
+    expect_equal(nrow(pecotmr:::.cfMaf(data.frame(AF = c(0.8, 0.01)), 0.05)$df), 1L)
+    expect_equal(nrow(pecotmr:::.cfMaf(data.frame(MAF = c(0.2, 0.01)), 0.05)$df), 1L)
+    expect_warning(
+        out <- pecotmr:::.cfMaf(data.frame(SNP = c("a", "b")), 0.05),
+        "skipping the MAF filter")
+    expect_equal(nrow(out$df), 2L)
+})
+
+test_that("harmonization complements the directional af on a swap; leaves maf", {
+    tgt <- data.frame(chrom = "1", pos = 100L, A2 = "G", A1 = "A", SNP = "v1",
+                      Z = 2.0, AF = 0.8, MAF = 0.2, stringsAsFactors = FALSE)
+    ref <- data.frame(chrom = "1", pos = 100L, A2 = "A", A1 = "G",
+                      variant_id = "v1", stringsAsFactors = FALSE)
+    res <- pecotmr:::harmonizeAlleles(tgt, ref, colToFlip = "Z",
+        colToComplement = "AF", matchMinProp = 0, removeStrandAmbiguous = FALSE)
+    h <- res$harmonizedData
+    expect_equal(h$AF, 0.2)   # complemented to the final effect allele
+    expect_equal(h$Z, -2.0)   # sign-flipped on the same swap
+    expect_equal(h$MAF, 0.2)  # directionless -> NOT complemented
 })


### PR DESCRIPTION
Restores the af/MAF semantic layer the S4 refactor (#521/#530) silently dropped — verified against the archived `rss-top-loci-af` / `rss-af-single-source` / `rss-qc-parity` contracts.

- **`af` is the directional effect-allele frequency**, declared only via an `af:` mapping key and exported as `top_loci$af` (complemented on allele harmonization). A directionless `maf` (`maf:`/`FRQ`) is QC-only and is **never** exported as `af`.
- **Undeclared / ambiguous / declared-but-missing af → `af = NA`** with distinct warnings (no more silent mislabeling; the loader used to route any `maf`/`effect_allele_frequency` into one field and export it as `af`).
- `.cfMaf` derives the filter MAF from `af` (`min(af,1-af)`), falls back to a directionless `maf`, and **skips-with-warning** instead of aborting when no frequency is available.
- Harmonization now complements the directional `AF` on an allele swap (not the swap-invariant `MAF`).

Flagship data (declares `effect_allele_frequency`) is **byte-identical** — only non-flagship / undeclared inputs now honestly get `af = NA`. `af` is not a `susie_rss` input, so PIP/CS are unaffected.

Tests: `test_sumstatsQc` 857/0 (new af/MAF cases incl. the harmonization complement), `fineMappingPipeline` 475/0, `fineMappingWrappers` 450/0; full suite 7114/3 (the 3 are pre-existing SNPRelate-missing env failures, zero new). Real chr21 AD_Bellenguez validated.

Pairs with the protocol BED rename (top_loci BED `MAF`→`af`).