### PR TITLE
Fix top_loci$N = 1 on the RSS path

### DIFF
--- a/R/fineMappingPipeline.R
+++ b/R/fineMappingPipeline.R
@@ -868,6 +868,7 @@ setGeneric("fineMappingPipeline", function(data, ...) {
         p$verbose,
         label = glue("GWAS (study='{st}', region='{blockId}')"),
         af = .fmAfByVar(gr, zn$variantIds),
+        nVar = zn$nVar,
         fullFit = p$fullFit,
         fullFitAlphaOnly = p$fullFitAlphaOnly,
         includeAllCs = p$includeAllCs,
@@ -952,6 +953,7 @@ setGeneric("fineMappingPipeline", function(data, ...) {
         p$verbose,
         label = glue("(study='{st}', context='{ctx}', trait='{tr}')"),
         af = .fmAfByVar(entry, zn$variantIds),
+        nVar = zn$nVar,
         fullFit = p$fullFit,
         fullFitAlphaOnly = p$fullFitAlphaOnly,
         includeAllCs = p$includeAllCs,
@@ -1170,6 +1172,7 @@ combineFineMappingResults <- function(..., ldSketch = NULL) {
     minAbsCorr,
     csInput = NULL,
     af = NULL,
+    n = NULL,
     region = NULL,
     trim = NULL,
     medianAbsCorr = NULL,
@@ -1192,6 +1195,7 @@ combineFineMappingResults <- function(..., ldSketch = NULL) {
         dataY,
         region,
         af,
+        n,
         csInput,
         conditionIdx,
         coverage,
@@ -1212,6 +1216,7 @@ combineFineMappingResults <- function(..., ldSketch = NULL) {
     dataY,
     region,
     af,
+    n,
     csInput,
     conditionIdx,
     coverage,
@@ -1225,6 +1230,7 @@ combineFineMappingResults <- function(..., ldSketch = NULL) {
         dataX = dataX,
         dataY = dataY,
         af = af,
+        n = n,
         coverage = coverage,
         secondaryCoverage = secondaryCoverage,
         signalCutoff = signalCutoff,
@@ -1743,7 +1749,11 @@ combineFineMappingResults <- function(..., ldSketch = NULL) {
     list(
         variantIds = df$variant_id,
         z = df$z,
-        n = stats::median(df$N, na.rm = TRUE)
+        # Scalar block N the RSS fit consumes (susie_rss takes a single n) ...
+        n = stats::median(df$N, na.rm = TRUE),
+        # ... and the per-variant effective N, aligned to `variantIds`, used only
+        # to populate the reporting-only top_loci$N column (never the fit).
+        nVar = df$N
     )
 }
 

--- a/R/fineMappingWrappers.R
+++ b/R/fineMappingWrappers.R
@@ -368,6 +368,7 @@ postprocessFinemappingFits <- function(
     xScalar = 1,
     yScalar = 1,
     af = NULL,
+    n = NULL,
     coverage = NULL,
     secondaryCoverage = c(0.7, 0.5),
     signalCutoff = 0.1,
@@ -518,6 +519,7 @@ postprocessFinemappingFit.susiF <- function(
     xScalar = 1,
     yScalar = 1,
     af = NULL,
+    n = NULL,
     coverage = NULL,
     secondaryCoverage = c(0.7, 0.5),
     signalCutoff = 0.1,
@@ -583,6 +585,7 @@ postprocessFinemappingFit.susiF <- function(
         variantNames = variantNames,
         sumstats = sumstats,
         af = p$af,
+        n = p$n,
         method = p$method,
         signalCutoff = 0,
         dataY = p$dataY,
@@ -1253,6 +1256,11 @@ setMethod(
 #'   LD/reference variants). Exported directly as the \code{af} column. MAF is
 #'   never exported; derive it from \code{af} at filter time. Default NULL ->
 #'   \code{af = NA_real_}.
+#' @param n Optional per-variant sample size, one entry per variant, exported as
+#'   the \code{N} column. Used by RSS fine-mapping, where the effective sample
+#'   size varies by variant. Default NULL -> \code{N} falls back to the fit's
+#'   scalar sample size (the outcome-matrix \code{nrow} for individual-level
+#'   fits, \code{NA} otherwise).
 #' @param method Method name (e.g. \code{"susie"}, \code{"susieInf"}). Required.
 #' @param signalCutoff PIP cutoff for retaining PIP-only (non-CS) variants.
 #' @param dataY Optional regional phenotype matrix; \code{nrow(dataY)} fills
@@ -1284,6 +1292,7 @@ buildTopLoci <- function(
     variantNames,
     sumstats = NULL,
     af = NULL,
+    n = NULL,
     method,
     signalCutoff = 0,
     dataY = NULL,
@@ -1330,6 +1339,7 @@ buildTopLoci <- function(
         post,
         p$fit,
         p$af,
+        p$n,
         p$method,
         .btlCsBlock(p$method, cs, nV),
         fullFitBlock,
@@ -1384,7 +1394,16 @@ buildTopLoci <- function(
 # Per-fit constants: sample size, gene (first phenotype column), event id, and
 # the parsed genomic range.
 .btlFitConstants <- function(dataY, otherQuantities, region) {
-    dataYMat <- if (!is.null(dataY)) as.matrix(dataY) else NULL
+    # Only a genuine sample-by-outcome matrix carries a meaningful nrow. RSS
+    # passes dataY as a list (e.g. list(z = ...)); as.matrix() on a list
+    # collapses it to a 1x1 cell, which used to make fitN (and every top_loci
+    # N) 1. Treat non-matrix dataY as "no fit N" and let the per-variant `n`
+    # (threaded from the RSS effective sample size) fill the N column instead.
+    dataYMat <- if (!is.null(dataY) && (is.matrix(dataY) || is.data.frame(dataY))) {
+        as.matrix(dataY)
+    } else {
+        NULL
+    }
     fitN <- if (is.null(dataYMat)) NA_integer_ else as.integer(nrow(dataYMat))
     fitGene <- if (!is.null(dataYMat) && !is.null(colnames(dataYMat))) {
         colnames(dataYMat)[1]
@@ -1712,6 +1731,7 @@ buildTopLoci <- function(
     post,
     fit,
     af,
+    n,
     method,
     csBlock,
     fullFitBlock,
@@ -1723,7 +1743,17 @@ buildTopLoci <- function(
         pos = as.integer(parsed$pos),
         A1 = unname(parsed$A1),
         A2 = unname(parsed$A2),
-        N = rep(fc$fitN, nV),
+        # Per-variant N (RSS): keep it numeric so a fractional *effective* N
+        # (e.g. 4 / (1/nCase + 1/nControl)) matches getSumstatDf(entry)$N exactly
+        # rather than being truncated. Fall back to the fit's scalar N (integer
+        # nrow on the QTL path, NA otherwise). A scalar n is recycled.
+        N = if (is.null(n)) {
+            rep(fc$fitN, nV)
+        } else if (length(n) == 1L) {
+            rep(as.numeric(n), nV)
+        } else {
+            as.numeric(n)
+        },
         af = if (is.null(af)) rep(NA_real_, nV) else as.numeric(af),
         marginal_beta = unname(marg$beta),
         marginal_se = unname(marg$se),
@@ -3630,6 +3660,7 @@ mergeSusieCs <- function(fineMappingResult, coverage = 0.95) {
     verbose,
     label,
     af = NULL,
+    nVar = NULL,
     fullFit = FALSE,
     fullFitAlphaOnly = TRUE,
     includeAllCs = FALSE,
@@ -3757,6 +3788,10 @@ mergeSusieCs <- function(fineMappingResult, coverage = 0.95) {
         signalCutoff = p$signalCutoff,
         minAbsCorr = p$minAbsCorr,
         af = p$af,
+        # Per-variant effective N (reporting-only, top_loci$N). NULL on any path
+        # that has no per-variant N -> buildTopLoci leaves N as NA, never 1.
+        # This is NOT p$n (the scalar median the RSS fit consumes).
+        n = p$nVar,
         csInput = "Xcorr",
         fullFit = p$fullFit,
         fullFitAlphaOnly = p$fullFitAlphaOnly,
@@ -3822,6 +3857,7 @@ mergeSusieCs <- function(fineMappingResult, coverage = 0.95) {
         xScalar = p$xScalar,
         yScalar = p$yScalar,
         af = p$af,
+        n = p$n,
         coverage = p$coverage,
         secondaryCoverage = p$secondaryCoverage,
         signalCutoff = p$signalCutoff,

--- a/man/buildTopLoci.Rd
+++ b/man/buildTopLoci.Rd
@@ -10,6 +10,7 @@ buildTopLoci(
   variantNames,
   sumstats = NULL,
   af = NULL,
+  n = NULL,
   method,
   signalCutoff = 0,
   dataY = NULL,
@@ -38,6 +39,12 @@ the final effect allele / \code{a1} after allele harmonization against the
 LD/reference variants). Exported directly as the \code{af} column. MAF is
 never exported; derive it from \code{af} at filter time. Default NULL ->
 \code{af = NA_real_}.}
+
+\item{n}{Optional per-variant sample size, one entry per variant, exported as
+the \code{N} column. Used by RSS fine-mapping, where the effective sample
+size varies by variant. Default NULL -> \code{N} falls back to the fit's
+scalar sample size (the outcome-matrix \code{nrow} for individual-level
+fits, \code{NA} otherwise).}
 
 \item{method}{Method name (e.g. \code{"susie"}, \code{"susieInf"}). Required.}
 

--- a/tests/testthat/test_fineMappingPipeline.R
+++ b/tests/testthat/test_fineMappingPipeline.R
@@ -2217,6 +2217,79 @@ test_that("fineMappingPipeline(GwasSumStats): runs end-to-end with mocked RSS fi
     expect_setequal(getMethodNames(res), "susie")
 })
 
+test_that("fineMappingPipeline(GwasSumStats): threads per-variant N into postprocess (not the median, not 1)", {
+    # Regression for top_loci$N == 1. The RSS path must forward the per-variant
+    # effective N (the entry's N column, aligned to the analysed variants) to the
+    # post-processor -- NOT the scalar median the SuSiE-RSS fit consumes, and
+    # never a list-collapsed 1.
+    snp_ids <- sprintf("chr1:%d:A:G", 100L * (1:5))
+    gr <- GenomicRanges::GRanges(
+        seqnames = "chr1",
+        ranges = IRanges::IRanges(
+            start = seq(100L, by = 100L, length.out = 5L),
+            width = 1L
+        )
+    )
+    perVarN <- c(1000L, 1100L, 1200L, 1300L, 1400L) # median = 1200, all distinct
+    S4Vectors::mcols(gr) <- S4Vectors::DataFrame(
+        SNP = snp_ids,
+        A1 = rep("A", 5L),
+        A2 = rep("G", 5L),
+        Z = rnorm(5L),
+        N = perVarN
+    )
+    gss <- GwasSumStats(
+        study = "G1",
+        entry = list(gr),
+        genome = "hg19",
+        ldSketch = .fmp_makeHandle(),
+        qcInfo = list(step1 = "ok")
+    )
+    captured <- new.env(parent = emptyenv())
+    captured$n <- "UNSET"
+    recording <- function(
+        fit,
+        method,
+        dataX,
+        dataY,
+        coverage,
+        secondaryCoverage,
+        signalCutoff,
+        minAbsCorr,
+        csInput = NULL,
+        af = NULL,
+        n = NULL,
+        ...
+    ) {
+        captured$n <- n
+        vids <- names(dataY$z)
+        if (is.null(vids)) {
+            vids <- snp_ids
+        }
+        fineMappingRow(
+            variantIds = vids,
+            susieFit = list(method = method),
+            topLoci = data.frame(
+                variant_id = vids,
+                pip = 0.5,
+                stringsAsFactors = FALSE
+            )
+        )
+    }
+    local_mocked_bindings(
+        extractBlockGenotypes = .fmp_mockExtractor(),
+        .fmFitSusieRss = .fmp_mockFitRss(),
+        .fmPostprocessOne = recording,
+        .package = "pecotmr"
+    )
+    suppressMessages(
+        fineMappingPipeline(gss, methods = "susie", addSusieInf = FALSE)
+    )
+    # per-variant N forwarded (all 5 distinct), not the scalar median, not 1.
+    expect_false(identical(captured$n, "UNSET"))
+    expect_equal(as.integer(captured$n), perVarN)
+})
+
 # ---- PIP-screen graceful skip: a screened region -> empty result, not error ----
 
 # A GwasSumStats whose (single) entry was emptied by summaryStatsQc's PIP screen:

--- a/tests/testthat/test_fineMappingWrappers.R
+++ b/tests/testthat/test_fineMappingWrappers.R
@@ -1000,6 +1000,52 @@ test_that("buildTopLoci emits 22 columns in the fixed order on a non-empty fit",
     expect_equal(unique(out$method), "susie")
 })
 
+test_that("buildTopLoci: RSS per-variant N is threaded; list dataY never collapses to 1", {
+    # Regression for top_loci$N == 1 on the RSS path: dataY = list(z = ...) made
+    # as.matrix() collapse to a 1x1 cell, so nrow (and every N) was 1. The
+    # per-variant effective N must instead be threaded into the N column.
+    variant_ids <- c("chr1:100:A:G", "chr1:200:C:T", "chr1:300:A:T")
+    inp <- .fake_fit_and_cs(
+        variant_ids,
+        cs_at_cov = list(
+            "0.95" = list(c(1L, 2L, 3L)),
+            "0.7" = list(c(1L, 2L, 3L)),
+            "0.5" = list(c(1L, 2L, 3L))
+        ),
+        nSamples = 5,
+        n_variants = length(variant_ids)
+    )
+    perVarN <- c(233257L, 250000L, 283145L)
+
+    # (3a) list dataY + a per-variant n -> N is exactly that per-variant vector.
+    out <- buildTopLoci(
+        fit = inp$fit,
+        csTables = inp$cs_tables,
+        variantNames = inp$variantNames,
+        af = NULL,
+        n = perVarN,
+        method = "susie",
+        signalCutoff = 0,
+        dataY = list(z = rnorm(length(variant_ids)))
+    )
+    ord <- match(variant_ids, out$variant_id)
+    expect_equal(out$N[ord], perVarN)
+    expect_false(any(out$N == 1L))
+
+    # (3b) list dataY + no n supplied -> N is NA (unknown), never the collapsed 1.
+    out_na <- buildTopLoci(
+        fit = inp$fit,
+        csTables = inp$cs_tables,
+        variantNames = inp$variantNames,
+        af = NULL,
+        method = "susie",
+        signalCutoff = 0,
+        dataY = list(z = rnorm(length(variant_ids)))
+    )
+    expect_true(is.numeric(out_na$N))
+    expect_true(all(is.na(out_na$N)))
+})
+
 test_that("buildTopLoci fullFit: within_cs_pip default + wide per-CS matrices", {
     vn <- paste0("chr1:", (1:5) * 100, ":A:G")
     L <- 2L


### PR DESCRIPTION
`top_loci$N` was `1` for every GWAS/RSS row. On the RSS path `buildTopLoci` receives `dataY = list(z = ...)`, and `as.matrix()` on a one-element list collapses to a 1x1 cell, so `.btlFitConstants` reported `nrow = 1`.

- Guard `.btlFitConstants`: take `nrow` only for a real matrix/data.frame; a list yields `NA`, never 1.
- Thread the per-variant effective N into `buildTopLoci` the way `af` is threaded. `.fmExtractZn` collapses the entry N to a scalar median (the single `n` `susie_rss` consumes), so it now also returns the per-variant `nVar`, which `.fmRssPostprocess` passes into the N column while the fit keeps using the median.

Reporting-only: `susie_rss` reads `n` from the entry, never from this column. On a real chr21 AD_Bellenguez block (7913 variants) `top_loci$N` goes from `{1}` to the per-variant effective N (49,090–283,145) and matches `getSumstatDf(entry)$N` exactly; PIP and every credible-set column are byte-identical to the pre-change run.

Regression tests added in `test_fineMappingWrappers.R` and `test_fineMappingPipeline.R`.