### PR TITLE
Add ldMafCutoff: reference-panel MAF filter to summaryStatsQc

### DIFF
--- a/R/ctwasPipeline.R
+++ b/R/ctwasPipeline.R
@@ -2579,11 +2579,12 @@ asCtwasResult <- function(finemapResult, keepSnps = FALSE) {
     if (length(kept) < 1L) {
         return(NULL)
     }
-    # The weight vector ctwas fits must live inside the region being fine-mapped:
-    # susie_rss gets that region's LD, and a gene reaching outside it yields a
-    # non-finite ELBO (and a non-finite fit_EM log-likelihood upstream). The
-    # SPAN stays the gene's full cis extent -- see .ctwasGeneEntry -- so a
-    # boundary gene is still detected and can be recovered by merge_regions.
+    # The weight vector ctwas fits must live inside the region being
+    # fine-mapped: susie_rss gets that region's LD, and a gene reaching
+    # outside it yields a non-finite ELBO (and a non-finite fit_EM
+    # log-likelihood upstream). The SPAN stays the gene's full cis extent --
+    # see .ctwasGeneEntry -- so a boundary gene is still detected and can be
+    # recovered by merge_regions.
     inRegion <- .ctwasInRegion(kept$vids, ctx$regionSnps)
     if (!any(inRegion)) {
         return(NULL)

--- a/R/fineMappingPipeline.R
+++ b/R/fineMappingPipeline.R
@@ -1751,8 +1751,8 @@ combineFineMappingResults <- function(..., ldSketch = NULL) {
         z = df$z,
         # Scalar block N the RSS fit consumes (susie_rss takes a single n) ...
         n = stats::median(df$N, na.rm = TRUE),
-        # ... and the per-variant effective N, aligned to `variantIds`, used only
-        # to populate the reporting-only top_loci$N column (never the fit).
+        # ... and the per-variant effective N, aligned to `variantIds`, used
+        # only for the reporting-only top_loci$N column (never the fit).
         nVar = df$N
     )
 }

--- a/R/fineMappingWrappers.R
+++ b/R/fineMappingWrappers.R
@@ -543,24 +543,27 @@ postprocessFinemappingFit.susiF <- function(
     # Always build the canonical unfiltered table; the FineMappingRow stores
     # it as-is so accessors can filter by PIP at query time.
     topLociFull <- .ppTopLoci(p, csTables, variantNames, sumstats)
-    # trim = TRUE stores a minimal subset of the fit; FALSE keeps the full
-    # untrimmed susie return (mu / mu2 / lbf_variable / V / ...).
-    storedFit <- if (isTRUE(trim)) {
-        trimFinemappingFit(
-            fit,
-            selectEffects(fit, priorEffTol),
-            method,
-            csTables
-        )
-    } else {
-        fit
-    }
     fmEntry <- fineMappingRow(
         variantIds = variantNames,
-        susieFit = storedFit,
+        susieFit = .ppStoredFit(p, csTables),
         topLoci = topLociFull
     )
     .ppAssembleRes(p, topLociFull, fmEntry, sumstats)
+}
+
+# The fit as stored: trim = TRUE keeps a minimal subset, FALSE the full
+# untrimmed susie return (mu / mu2 / lbf_variable / V / ...).
+# @noRd
+.ppStoredFit <- function(p, csTables) {
+    if (!isTRUE(p$trim)) {
+        return(p$fit)
+    }
+    trimFinemappingFit(
+        p$fit,
+        selectEffects(p$fit, p$priorEffTol),
+        p$method,
+        csTables
+    )
 }
 
 # Credible-set tables for the fit at the requested coverages.
@@ -1391,6 +1394,21 @@ buildTopLoci <- function(
     if (is.null(cov)) rep(NA_real_, length(csTables)) else cov
 }
 
+# The per-variant N column. Numeric, so a fractional *effective* N (e.g.
+# 4 / (1 / nCase + 1 / nControl)) matches getSumstatDf(entry)$N exactly rather
+# than being truncated. With no per-variant n this falls back to the fit's
+# scalar N (integer nrow on the QTL path, NA otherwise); a scalar n recycles.
+# @noRd
+.btlNColumn <- function(n, fitN, nV) {
+    if (is.null(n)) {
+        return(rep(fitN, nV))
+    }
+    if (length(n) == 1L) {
+        return(rep(as.numeric(n), nV))
+    }
+    as.numeric(n)
+}
+
 # Per-fit constants: sample size, gene (first phenotype column), event id, and
 # the parsed genomic range.
 .btlFitConstants <- function(dataY, otherQuantities, region) {
@@ -1399,11 +1417,9 @@ buildTopLoci <- function(
     # collapses it to a 1x1 cell, which used to make fitN (and every top_loci
     # N) 1. Treat non-matrix dataY as "no fit N" and let the per-variant `n`
     # (threaded from the RSS effective sample size) fill the N column instead.
-    dataYMat <- if (!is.null(dataY) && (is.matrix(dataY) || is.data.frame(dataY))) {
-        as.matrix(dataY)
-    } else {
-        NULL
-    }
+    hasOutcomeMatrix <- !is.null(dataY) &&
+        (is.matrix(dataY) || is.data.frame(dataY))
+    dataYMat <- if (hasOutcomeMatrix) as.matrix(dataY) else NULL
     fitN <- if (is.null(dataYMat)) NA_integer_ else as.integer(nrow(dataYMat))
     fitGene <- if (!is.null(dataYMat) && !is.null(colnames(dataYMat))) {
         colnames(dataYMat)[1]
@@ -1743,17 +1759,7 @@ buildTopLoci <- function(
         pos = as.integer(parsed$pos),
         A1 = unname(parsed$A1),
         A2 = unname(parsed$A2),
-        # Per-variant N (RSS): keep it numeric so a fractional *effective* N
-        # (e.g. 4 / (1/nCase + 1/nControl)) matches getSumstatDf(entry)$N exactly
-        # rather than being truncated. Fall back to the fit's scalar N (integer
-        # nrow on the QTL path, NA otherwise). A scalar n is recycled.
-        N = if (is.null(n)) {
-            rep(fc$fitN, nV)
-        } else if (length(n) == 1L) {
-            rep(as.numeric(n), nV)
-        } else {
-            as.numeric(n)
-        },
+        N = .btlNColumn(n, fc$fitN, nV),
         af = if (is.null(af)) rep(NA_real_, nV) else as.numeric(af),
         marginal_beta = unname(marg$beta),
         marginal_se = unname(marg$se),

--- a/R/ld.R
+++ b/R/ld.R
@@ -990,12 +990,105 @@ loadLdFromGenotype <- function(
     )
 }
 
+# A MAC cutoff is a MAF cutoff once expressed per panel sample, so the
+# stricter of the two applies -- the same rule .qtlVariantFilters() uses on
+# individual level data, so one number means the same thing on both paths.
+# @noRd
+.panelEffectiveMaf <- function(mafCutoff, macCutoff, nSamples) {
+    macAsMaf <- if (nSamples > 0L) macCutoff / (2 * nSamples) else 0
+    max(mafCutoff, macAsMaf)
+}
+
+# The .afreq stems to read for a panel: the handle's own stem, or one per
+# chromosome the panel actually spans. A sharded handle lists every
+# chromosome in its manifest, and reading the shards the summary statistics
+# never touch is the cost per-chromosome sketch trimming exists to avoid.
+# @noRd
+.panelAfreqPrefixes <- function(handle) {
+    chromPaths <- .genotypeChromPaths(handle)
+    if (length(chromPaths) == 0L) {
+        return(.genotypeReadPath(handle))
+    }
+    spanned <- unique(canonChrom(as.character(getSnpInfo(handle)$CHR)))
+    paths <- unname(chromPaths[is_in(names(chromPaths), spanned)])
+    map_chr(paths, .resolveGenotypeResourcePath)
+}
+
+# One shard's id/alt_freq pairs, or NULL when the sidecar is missing or does
+# not carry them. A malformed sidecar must not take the whole filter down, so
+# it degrades to "no frequencies here" and the caller falls back to dosage.
+# @noRd
+.panelAfreqTable <- function(prefix) {
+    af <- tryCatch(readAfreq(prefix), error = function(e) NULL)
+    if (is.null(af) || !all(is_in(c("id", "alt_freq"), colnames(af)))) {
+        return(NULL)
+    }
+    select(af, all_of(c("id", "alt_freq")))
+}
+
+# Panel minor allele frequency for `variantIds` read from the PLINK2 .afreq
+# sidecar, or NULL when the sidecar cannot answer for every id.
+#
+# Refusing a PARTIAL sidecar is deliberate: the dosage path treats a variant
+# it cannot measure as a drop, so a fast path that quietly kept the ids
+# .afreq happens to omit would disagree with it about the same variant.
+# @noRd
+.panelAfreqMaf <- function(handle, variantIds) {
+    if (getFormat(handle) != "plink2") {
+        return(NULL)
+    }
+    tbls <- compact(map(.panelAfreqPrefixes(handle), .panelAfreqTable))
+    if (length(tbls) == 0L) {
+        return(NULL)
+    }
+    afTbl <- list_rbind(tbls)
+    idx <- match(variantIds, pull(afTbl, "id"))
+    if (anyNA(idx)) {
+        return(NULL)
+    }
+    altFreq <- as.numeric(pull(afTbl, "alt_freq"))[idx]
+    pmin(altFreq, 1 - altFreq)
+}
+
+# TRUE for each matched panel variant that fails the cutoffs.
+#
+# Allele frequency alone answers MAF and MAC, so with no missingness cutoff
+# set the .afreq sidecar decides the whole mask without materializing panel
+# dosage -- which is what makes the filter affordable on a panel far larger
+# than the analysed variant set. Missingness is not derivable from the
+# sidecar (its observation count is an ALLELE count, whose ploidy the mask
+# would have to guess), so an imissCutoff always takes the dosage path.
+# @noRd
+.panelDropMask <- function(
+    handle,
+    matched,
+    mafCutoff,
+    macCutoff,
+    imissCutoff
+) {
+    if (imissCutoff >= 1) {
+        # Keyed on the PANEL's own variant labels, not the caller's: .afreq
+        # carries the .pvar ids, while `keptIds` is whatever id form the
+        # caller asked in (normalized, most often).
+        panelIds <- as.character(getSnpInfo(handle)$SNP)[matched$idx]
+        maf <- .panelAfreqMaf(handle, panelIds)
+        if (!is.null(maf)) {
+            effMaf <- .panelEffectiveMaf(
+                mafCutoff,
+                macCutoff,
+                getNSamples(handle)
+            )
+            return(is.na(maf) | maf < effMaf)
+        }
+    }
+    dosage <- .dosageMatrix(handle, matched$idx, meanImpute = FALSE)
+    stats <- .panelVariantStats(dosage)
+    effMaf <- .panelEffectiveMaf(mafCutoff, macCutoff, nrow(dosage))
+    is.na(stats$maf) | stats$maf < effMaf | stats$missRate > imissCutoff
+}
+
 # The subset of `variantIds` whose LD-panel genotypes clear the cutoffs,
 # returned in the caller's order.
-#
-# A MAC cutoff is a MAF cutoff once expressed per panel sample, so the stricter
-# of the two applies -- the same rule .qtlVariantFilters() uses on individual
-# level data, so one number means the same thing on both paths.
 #
 # Variants absent from the panel are passed through untouched. Whether a
 # missing variant is an error or is silently dropped belongs to `.ldFromSketch`
@@ -1023,20 +1116,13 @@ loadLdFromGenotype <- function(
     if (is.null(matched)) {
         return(variantIds)
     }
-    dosage <- .dosageMatrix(
+    drop <- .panelDropMask(
         .ldSketchHandle(ldSketch),
-        matched$idx,
-        meanImpute = FALSE
-    )
-    stats <- .panelVariantStats(dosage)
-    nSamp <- nrow(dosage)
-    effectiveMaf <- max(
+        matched,
         mafCutoff,
-        if (nSamp > 0L) macCutoff / (2 * nSamp) else 0
+        macCutoff,
+        imissCutoff
     )
-    drop <- is.na(stats$maf) |
-        stats$maf < effectiveMaf |
-        stats$missRate > imissCutoff
     variantIds[!is_in(variantIds, matched$keptIds[drop])]
 }
 

--- a/R/sumstatsQc.R
+++ b/R/sumstatsQc.R
@@ -2866,7 +2866,14 @@ krigingOutlierQc <- function(
     # AF = directional effect-allele frequency (exported as af); MAF =
     # directionless QC frequency. Both carried when the loader resolved them.
     optCols <- c(
-        "AF", "MAF", "INFO", "BETA", "SE", "P", "N_CASE", "N_CONTROL"
+        "AF",
+        "MAF",
+        "INFO",
+        "BETA",
+        "SE",
+        "P",
+        "N_CASE",
+        "N_CONTROL"
     )
     use <- intersect(c(baseCols, optCols), colnames(df))
     S4Vectors::mcols(gr) <- S4Vectors::DataFrame(select(df, all_of(use)))
@@ -3937,13 +3944,7 @@ krigingOutlierQc <- function(
         (.raissUnsafeToImpute(refPanel$variant_id, knownZ$variant_id) |
             .raissObservedPosition(refPanel, knownZ))
     stats <- .qcRaissVariantStats(dosage)
-    # A MAC cutoff is a MAF cutoff once expressed per panel sample; taking the
-    # stricter of the two matches .qtlVariantFilters().
-    nSamp <- nrow(dosage)
-    effectiveMaf <- max(
-        mafCutoff,
-        if (nSamp > 0L) macCutoff / (2 * nSamp) else 0
-    )
+    effectiveMaf <- .panelEffectiveMaf(mafCutoff, macCutoff, nrow(dosage))
     fails <- (!is.na(stats$maf) & stats$maf < effectiveMaf) |
         stats$missRate > imissCutoff |
         is.na(stats$maf)
@@ -4631,13 +4632,40 @@ krigingOutlierQc <- function(
     }
 }
 
+# TRUE for a single finite non-negative cutoff value.
+# @noRd
+.ssqcIsCutoff <- function(x) {
+    is.numeric(x) && length(x) == 1L && !is.na(x) && is.finite(x) && x >= 0
+}
+
+# Shape-check the panel-filter trio. Runs before the panel is opened, so a
+# malformed cutoff fails on the call rather than after a dosage read.
+# @noRd
+.ssqcCheckPanelCutoffs <- function(mafCutoff, macCutoff, imissCutoff) {
+    cutoffs <- list(
+        mafCutoff = mafCutoff,
+        macCutoff = macCutoff,
+        imissCutoff = imissCutoff
+    )
+    bad <- names(cutoffs)[!map_lgl(cutoffs, .ssqcIsCutoff)]
+    if (length(bad) > 0L) {
+        msg <- glue(
+            "summaryStatsQc: {str_flatten(bad, ', ')} must each be a single ",
+            "finite number >= 0."
+        )
+        abort(msg)
+    }
+    invisible(NULL)
+}
+
 # Build the per-entry QC options list from the captured call parameters.
 .ssqcBuildOpts <- function(p) {
     optNames <- c(
         "removeIndels",
         "removeStrandAmbiguous",
         "mafCutoff",
-        "ldMafCutoff",
+        "macCutoff",
+        "imissCutoff",
         "infoCutoff",
         "nCutoff",
         "skipRegion",
@@ -4711,46 +4739,16 @@ krigingOutlierQc <- function(
     }
 }
 
-# Run the per-entry QC pipeline across all entries.
-# Per-variant ALT (A1 / effect-allele) frequency for the panel behind `handle`,
-# read from the .afreq sidecar(s) and aligned to `ids` (NA where a variant has
-# no .afreq row). Handles both a genome-wide handle (single prefix) and a
-# chrom-meta handle (one prefix per chromosome). Returns NULL when no .afreq is
-# available (or none of the ids match), so the caller falls back to genotypes.
+# Drop the reference-panel variants that fail the MAF / MAC / missingness
+# cutoffs, returning the pruned sketch. NULL cutoffs (the default) are a no-op.
+#
+# Pruning the PANEL rather than masking a variant list is what makes one
+# cutoff reach every reader: harmonization drops the study variants the
+# retained panel no longer covers, and kriging, SLALOM/DENTIST and the RAISS
+# known/unknown split then only ever see what survived.
 # @noRd
-.panelAltFreqFromAfreq <- function(handle, ids) {
-    chromPaths <- .genotypeChromPaths(handle)
-    prefixes <- if (length(chromPaths) > 0L) unname(chromPaths) else handle@path
-    tbls <- lapply(prefixes, function(pfx) {
-        a <- tryCatch(readAfreq(pfx), error = function(e) NULL)
-        if (is.null(a) || !all(is_in(c("id", "alt_freq"), colnames(a)))) {
-            return(NULL)
-        }
-        a[, c("id", "alt_freq"), drop = FALSE]
-    })
-    tbls <- Filter(Negate(is.null), tbls)
-    if (length(tbls) == 0L) {
-        return(NULL)
-    }
-    afTbl <- do.call(rbind, tbls)
-    m <- match(ids, afTbl$id)
-    if (all(is.na(m))) {
-        return(NULL)
-    }
-    as.numeric(afTbl$alt_freq)[m]
-}
-
-# Drop reference-panel variants whose panel MAF (min(altFreq, 1 - altFreq)) is
-# below `cutoff`, returning the pruned ldSketch. The prune happens BEFORE any LD
-# is materialized and before RAISS picks imputation targets, so a dropped
-# variant is neither used in the LD nor imputed back. Frequencies come from the
-# panel's .afreq sidecar (no genotypes read); a panel with no .afreq falls back
-# to a single dosage pass via .panelVariantFilter. A cutoff <= 0 (or a NULL
-# sketch) is a no-op, keeping the default path byte-preserving.
-# @noRd
-.ssqcPanelMafPrune <- function(ldSketch, cutoff, label) {
-    cutoff <- cutoff %||% 0
-    if (!is.finite(cutoff) || cutoff <= 0 || is.null(ldSketch)) {
+.ssqcPrunePanel <- function(ldSketch, cutoffs, label) {
+    if (is.null(ldSketch) || is.null(cutoffs)) {
         return(ldSketch)
     }
     handle <- .ldSketchHandle(ldSketch)
@@ -4758,60 +4756,35 @@ krigingOutlierQc <- function(
     if (length(ids) == 0L) {
         return(ldSketch)
     }
-    af <- .panelAltFreqFromAfreq(handle, ids)
-    keep <- if (!is.null(af)) {
-        maf <- pmin(af, 1 - af)
-        # Keep variants with no .afreq row (unmeasurable) rather than dropping
-        # them on a metadata gap; drop only those measured below the cutoff.
-        is.na(maf) | maf >= cutoff
-    } else {
-        # No .afreq anywhere: derive the frequency from a single dosage pass and
-        # reuse the existing panel filter, then map its kept ids back to a mask.
-        kept <- .panelVariantFilter(
-            ldSketch,
-            ids,
-            mafCutoff = cutoff,
-            label = label
-        )
-        is_in(ids, kept)
-    }
-    nDropped <- sum(!keep)
-    if (nDropped > 0L) {
-        .qcEmit(
-            label,
-            glue(
-                "LD-panel MAF filter (ldMafCutoff = {cutoff}): dropped ",
-                "{nDropped} of {length(ids)} reference variant(s) before ",
-                "LD / imputation."
-            )
-        )
-    }
+    keep <- .panelKeepMask(ids, ldSketch, cutoffs, label)
     if (all(keep)) {
         return(ldSketch)
     }
-    # Prune the underlying GenotypeHandle, not just an RSE row-view. Harmonize,
-    # kriging, mismatch-QC and RAISS all read the panel through
-    # `.ldSketchHandle()` -- the dosage DelayedArray's seed handle -- and RSE
-    # row subsetting (`sketch[keep, ]`) leaves that seed carrying the whole
-    # panel (see the `.emptySketch` note). Rebuild the sketch from the pruned
-    # handle so the drop actually reaches every reader.
-    prunedHandle <- .subsetGenotypeHandle(handle, keep)
+    # Prune the underlying GenotypeHandle, not just an RSE row view. Every
+    # reader reaches the panel through `.ldSketchHandle()` -- the dosage
+    # DelayedArray's seed -- and `sketch[keep, ]` leaves that seed carrying
+    # the whole panel (the trap `.emptySketch()` documents). Rebuild the
+    # sketch from the pruned handle so the drop reaches all of them.
+    pruned <- .subsetGenotypeHandle(handle, keep)
     if (methods::is(ldSketch, "GenotypeHandle")) {
-        return(prunedHandle)
+        return(pruned)
     }
-    .genotypeExperiment(prunedHandle)
+    .genotypeExperiment(pruned)
 }
 
+# Run the per-entry QC pipeline across all entries.
 .ssqcRunEntries <- function(sumstats, opts) {
     newEntries <- vector("list", nrow(sumstats))
     entryAudits <- vector("list", nrow(sumstats))
     isQtl <- methods::is(sumstats, "QtlSumStats")
-    ldSketch <- getLdSketch(sumstats)
-    # Panel-side MAF prune, once for the shared LD reference, BEFORE any entry is
-    # harmonized / mismatch-QC'd / imputed. Dropping variants from the sketch
-    # here means every downstream read (LD sketch, RAISS known/unknown split)
-    # only ever sees the retained panel. A cutoff <= 0 is a no-op.
-    ldSketch <- .ssqcPanelMafPrune(ldSketch, opts$ldMafCutoff, "summaryStatsQc")
+    # Panel filter, once for the shared LD reference and BEFORE any entry is
+    # harmonized, so a variant the panel cannot support is gone from the LD
+    # and from the summary statistics alike.
+    ldSketch <- .ssqcPrunePanel(
+        getLdSketch(sumstats),
+        .panelCutoffs(opts),
+        "summaryStatsQc"
+    )
     refGenome <- getGenome(sumstats)
     for (i in seq_len(nrow(sumstats))) {
         opts <- .ssqcEntryOpts(opts, sumstats, i)
@@ -4825,7 +4798,11 @@ krigingOutlierQc <- function(
         newEntries[[i]] <- result$gr
         entryAudits[[i]] <- result$audit
     }
-    list(newEntries = newEntries, entryAudits = entryAudits)
+    list(
+        newEntries = newEntries,
+        entryAudits = entryAudits,
+        ldSketch = ldSketch
+    )
 }
 
 # Assemble the qcInfo record (echoed options + per-entry audits).
@@ -4834,7 +4811,8 @@ krigingOutlierQc <- function(
         "removeIndels",
         "removeStrandAmbiguous",
         "mafCutoff",
-        "ldMafCutoff",
+        "macCutoff",
+        "imissCutoff",
         "infoCutoff",
         "nCutoff",
         "pipCutoffToSkip",
@@ -4923,30 +4901,48 @@ krigingOutlierQc <- function(
 #' etc.). Fine-mapping and TWAS-weights pipelines reject SumStats inputs where
 #' \code{length(getQcInfo(x)) == 0L}.
 #'
-#' Column-availability error contract: a non-zero \code{mafCutoff} requires
-#' every entry to carry a \code{MAF} column; non-zero \code{infoCutoff} requires
-#' \code{INFO}; non-zero \code{nCutoff} requires \code{N}. Missing column with a
-#' non-zero cutoff is a hard error.
+#' Column-availability error contract: a non-zero \code{infoCutoff} requires
+#' every entry to carry an \code{INFO} column, and a non-zero \code{nCutoff}
+#' requires \code{N}; a missing column with a non-zero cutoff is a hard error.
+#' \code{mafCutoff} is exempt --- a study with no frequency column is still
+#' filtered against the reference panel (see below).
+#'
+#' @section Panel filters: \code{mafCutoff} / \code{macCutoff} /
+#'   \code{imissCutoff} are measured against the \strong{LD reference panel},
+#'   the same way \code{\link{fineMappingPipeline}} and
+#'   \code{\link{twasWeightsPipeline}} measure them on the RSS path, so one
+#'   number means the same thing wherever it is set. MAC is converted to a MAF
+#'   equivalent and the stricter of the two applies, matching
+#'   \code{\link{QtlDataset}}. Defaults (\code{0}, \code{0}, \code{1}) filter
+#'   nothing.
+#'
+#'   The panel is filtered once, before any entry is harmonized, so a variant
+#'   the panel cannot support is absent from the LD used by kriging,
+#'   SLALOM/DENTIST and RAISS, and is never an imputation target. Because
+#'   harmonization drops summary-statistic variants the panel does not cover,
+#'   this also \strong{discards observed variants} --- the intended behaviour:
+#'   a variant whose LD cannot be estimated is not usable downstream.
+#'
+#'   \code{mafCutoff} additionally filters the summary statistics' own
+#'   \code{AF} / \code{MAF} / \code{FRQ} column when one is present, so a
+#'   variant common in the panel but rare in the study is dropped as well.
 #'
 #' @param sumstats A \code{QtlSumStats} or \code{GwasSumStats} collection.
 #' @param removeIndels Logical (length 1). When \code{TRUE}, drop indels during
 #'   panel harmonization. Default \code{FALSE}.
 #' @param removeStrandAmbiguous Logical (length 1). When \code{TRUE}, drop A/T
 #'   and C/G strand-ambiguous variants. Default \code{TRUE}.
-#' @param mafCutoff Numeric (length 1). MAF threshold (variants with \code{MAF <
-#'   mafCutoff} are dropped). Default 0. Requires \code{MAF} or \code{FRQ}
-#'   column when non-zero. This is the \emph{study}-side filter, applied to the
-#'   summary statistics' own MAF/FRQ; it is independent of \code{ldMafCutoff}.
-#' @param ldMafCutoff Numeric (length 1, >= 0). \emph{Reference-panel} MAF
-#'   threshold. When \code{> 0}, panel variants whose panel MAF
-#'   (\code{min(altFreq, 1 - altFreq)}) is below it are dropped from the LD
-#'   reference \emph{before} the LD is materialized and before RAISS selects
-#'   imputation targets, so a dropped variant is neither used in the LD nor
-#'   imputed back. Panel frequencies are read from the panel's \code{.afreq}
-#'   sidecar (no genotypes loaded); a panel without \code{.afreq} falls back to a
-#'   single dosage pass. Default 0 (off), leaving existing callers
-#'   byte-preserving. Independent of, and composes with, the study-side
-#'   \code{mafCutoff}.
+#' @param mafCutoff Numeric (length 1). Minor-allele-frequency threshold,
+#'   measured wherever it can be: against the summary statistics' own
+#'   \code{AF} / \code{MAF} / \code{FRQ} column when one is present, and
+#'   against the LD reference panel. Default 0 (off). See the panel-filters
+#'   section below.
+#' @param macCutoff Numeric (length 1). Minor-allele-count threshold for the
+#'   LD reference panel, converted to a MAF equivalent using
+#'   \code{macCutoff / (2 * nSamples)}; the stricter of it and
+#'   \code{mafCutoff} applies. Default 0 (off).
+#' @param imissCutoff Numeric (length 1). Per-variant missingness-rate ceiling
+#'   for the LD reference panel. Default 1 (off).
 #' @param infoCutoff Numeric (length 1). INFO score threshold. Default 0.
 #'   Requires \code{INFO} column when non-zero.
 #' @param nCutoff Numeric (length 1). Sample-size deviation threshold: drop
@@ -5008,10 +5004,14 @@ krigingOutlierQc <- function(
 #'   \code{mafCutoff} and \code{macCutoff / (2 * nSamples)} applies, matching
 #'   \code{\link{QtlDataset}}.
 #'
-#'   These bound what is \strong{imputed}, not what is kept: a variant present
-#'   in the sumstats survives whatever its frequency in the panel, both because
-#'   it is observed data and because RAISS derives its LD basis from those same
-#'   panel rows.
+#'   These are a \strong{further} tightening applied to imputation targets
+#'   only, on top of the panel filter the top-level cutoffs already applied:
+#'   the panel handed to RAISS holds nothing below those. Use them to impute
+#'   only common variants from a panel deliberately kept wider than that ---
+#'   e.g. \code{mafCutoff = 0.001} with
+#'   \code{imputeOpts = list(mafCutoff = 0.01)}. A variant present in the
+#'   sumstats is never dropped here: RAISS derives its LD basis from those
+#'   same panel rows.
 #' @param matchMinProp Minimum proportion of LD panel variants that must be
 #'   matched by the sumstats; default 0.
 #' @param coerceNumeric Logical. Coerce signed columns
@@ -5046,7 +5046,8 @@ summaryStatsQc <- function(
     removeIndels = FALSE,
     removeStrandAmbiguous = TRUE,
     mafCutoff = 0,
-    ldMafCutoff = 0,
+    macCutoff = 0,
+    imissCutoff = 1,
     infoCutoff = 0,
     nCutoff = 5,
     keepVariants = NULL,
@@ -5078,19 +5079,14 @@ summaryStatsQc <- function(
 ) {
     zMismatchQc <- arg_match(zMismatchQc)
     .ssqcCheckEntries(sumstats, mafCutoff, infoCutoff)
-    if (
-        !is.numeric(ldMafCutoff) ||
-            length(ldMafCutoff) != 1L ||
-            is.na(ldMafCutoff) ||
-            ldMafCutoff < 0
-    ) {
-        abort("summaryStatsQc: `ldMafCutoff` must be a single number >= 0.")
-    }
+    .ssqcCheckPanelCutoffs(mafCutoff, macCutoff, imissCutoff)
     p <- as.list(environment())
     opts <- .ssqcBuildOpts(p)
     res <- .ssqcRunEntries(sumstats, opts)
     qcInfo <- .ssqcBuildQcInfo(p, res$entryAudits)
-    newLdSketch <- .subsetSketchToIds(getLdSketch(sumstats), res$newEntries)
+    # From the PRUNED panel, not the input's: narrowing the original again
+    # would hand back a sketch the panel filter never reached.
+    newLdSketch <- .subsetSketchToIds(res$ldSketch, res$newEntries)
     .ssqcRebuild(sumstats, res$newEntries, newLdSketch, qcInfo)
 }
 

--- a/R/sumstatsQc.R
+++ b/R/sumstatsQc.R
@@ -4637,6 +4637,7 @@ krigingOutlierQc <- function(
         "removeIndels",
         "removeStrandAmbiguous",
         "mafCutoff",
+        "ldMafCutoff",
         "infoCutoff",
         "nCutoff",
         "skipRegion",
@@ -4711,11 +4712,106 @@ krigingOutlierQc <- function(
 }
 
 # Run the per-entry QC pipeline across all entries.
+# Per-variant ALT (A1 / effect-allele) frequency for the panel behind `handle`,
+# read from the .afreq sidecar(s) and aligned to `ids` (NA where a variant has
+# no .afreq row). Handles both a genome-wide handle (single prefix) and a
+# chrom-meta handle (one prefix per chromosome). Returns NULL when no .afreq is
+# available (or none of the ids match), so the caller falls back to genotypes.
+# @noRd
+.panelAltFreqFromAfreq <- function(handle, ids) {
+    chromPaths <- .genotypeChromPaths(handle)
+    prefixes <- if (length(chromPaths) > 0L) unname(chromPaths) else handle@path
+    tbls <- lapply(prefixes, function(pfx) {
+        a <- tryCatch(readAfreq(pfx), error = function(e) NULL)
+        if (is.null(a) || !all(is_in(c("id", "alt_freq"), colnames(a)))) {
+            return(NULL)
+        }
+        a[, c("id", "alt_freq"), drop = FALSE]
+    })
+    tbls <- Filter(Negate(is.null), tbls)
+    if (length(tbls) == 0L) {
+        return(NULL)
+    }
+    afTbl <- do.call(rbind, tbls)
+    m <- match(ids, afTbl$id)
+    if (all(is.na(m))) {
+        return(NULL)
+    }
+    as.numeric(afTbl$alt_freq)[m]
+}
+
+# Drop reference-panel variants whose panel MAF (min(altFreq, 1 - altFreq)) is
+# below `cutoff`, returning the pruned ldSketch. The prune happens BEFORE any LD
+# is materialized and before RAISS picks imputation targets, so a dropped
+# variant is neither used in the LD nor imputed back. Frequencies come from the
+# panel's .afreq sidecar (no genotypes read); a panel with no .afreq falls back
+# to a single dosage pass via .panelVariantFilter. A cutoff <= 0 (or a NULL
+# sketch) is a no-op, keeping the default path byte-preserving.
+# @noRd
+.ssqcPanelMafPrune <- function(ldSketch, cutoff, label) {
+    cutoff <- cutoff %||% 0
+    if (!is.finite(cutoff) || cutoff <= 0 || is.null(ldSketch)) {
+        return(ldSketch)
+    }
+    handle <- .ldSketchHandle(ldSketch)
+    ids <- as.character(getSnpInfo(handle)$SNP)
+    if (length(ids) == 0L) {
+        return(ldSketch)
+    }
+    af <- .panelAltFreqFromAfreq(handle, ids)
+    keep <- if (!is.null(af)) {
+        maf <- pmin(af, 1 - af)
+        # Keep variants with no .afreq row (unmeasurable) rather than dropping
+        # them on a metadata gap; drop only those measured below the cutoff.
+        is.na(maf) | maf >= cutoff
+    } else {
+        # No .afreq anywhere: derive the frequency from a single dosage pass and
+        # reuse the existing panel filter, then map its kept ids back to a mask.
+        kept <- .panelVariantFilter(
+            ldSketch,
+            ids,
+            mafCutoff = cutoff,
+            label = label
+        )
+        is_in(ids, kept)
+    }
+    nDropped <- sum(!keep)
+    if (nDropped > 0L) {
+        .qcEmit(
+            label,
+            glue(
+                "LD-panel MAF filter (ldMafCutoff = {cutoff}): dropped ",
+                "{nDropped} of {length(ids)} reference variant(s) before ",
+                "LD / imputation."
+            )
+        )
+    }
+    if (all(keep)) {
+        return(ldSketch)
+    }
+    # Prune the underlying GenotypeHandle, not just an RSE row-view. Harmonize,
+    # kriging, mismatch-QC and RAISS all read the panel through
+    # `.ldSketchHandle()` -- the dosage DelayedArray's seed handle -- and RSE
+    # row subsetting (`sketch[keep, ]`) leaves that seed carrying the whole
+    # panel (see the `.emptySketch` note). Rebuild the sketch from the pruned
+    # handle so the drop actually reaches every reader.
+    prunedHandle <- .subsetGenotypeHandle(handle, keep)
+    if (methods::is(ldSketch, "GenotypeHandle")) {
+        return(prunedHandle)
+    }
+    .genotypeExperiment(prunedHandle)
+}
+
 .ssqcRunEntries <- function(sumstats, opts) {
     newEntries <- vector("list", nrow(sumstats))
     entryAudits <- vector("list", nrow(sumstats))
     isQtl <- methods::is(sumstats, "QtlSumStats")
     ldSketch <- getLdSketch(sumstats)
+    # Panel-side MAF prune, once for the shared LD reference, BEFORE any entry is
+    # harmonized / mismatch-QC'd / imputed. Dropping variants from the sketch
+    # here means every downstream read (LD sketch, RAISS known/unknown split)
+    # only ever sees the retained panel. A cutoff <= 0 is a no-op.
+    ldSketch <- .ssqcPanelMafPrune(ldSketch, opts$ldMafCutoff, "summaryStatsQc")
     refGenome <- getGenome(sumstats)
     for (i in seq_len(nrow(sumstats))) {
         opts <- .ssqcEntryOpts(opts, sumstats, i)
@@ -4738,6 +4834,7 @@ krigingOutlierQc <- function(
         "removeIndels",
         "removeStrandAmbiguous",
         "mafCutoff",
+        "ldMafCutoff",
         "infoCutoff",
         "nCutoff",
         "pipCutoffToSkip",
@@ -4838,7 +4935,18 @@ krigingOutlierQc <- function(
 #'   and C/G strand-ambiguous variants. Default \code{TRUE}.
 #' @param mafCutoff Numeric (length 1). MAF threshold (variants with \code{MAF <
 #'   mafCutoff} are dropped). Default 0. Requires \code{MAF} or \code{FRQ}
-#'   column when non-zero.
+#'   column when non-zero. This is the \emph{study}-side filter, applied to the
+#'   summary statistics' own MAF/FRQ; it is independent of \code{ldMafCutoff}.
+#' @param ldMafCutoff Numeric (length 1, >= 0). \emph{Reference-panel} MAF
+#'   threshold. When \code{> 0}, panel variants whose panel MAF
+#'   (\code{min(altFreq, 1 - altFreq)}) is below it are dropped from the LD
+#'   reference \emph{before} the LD is materialized and before RAISS selects
+#'   imputation targets, so a dropped variant is neither used in the LD nor
+#'   imputed back. Panel frequencies are read from the panel's \code{.afreq}
+#'   sidecar (no genotypes loaded); a panel without \code{.afreq} falls back to a
+#'   single dosage pass. Default 0 (off), leaving existing callers
+#'   byte-preserving. Independent of, and composes with, the study-side
+#'   \code{mafCutoff}.
 #' @param infoCutoff Numeric (length 1). INFO score threshold. Default 0.
 #'   Requires \code{INFO} column when non-zero.
 #' @param nCutoff Numeric (length 1). Sample-size deviation threshold: drop
@@ -4938,6 +5046,7 @@ summaryStatsQc <- function(
     removeIndels = FALSE,
     removeStrandAmbiguous = TRUE,
     mafCutoff = 0,
+    ldMafCutoff = 0,
     infoCutoff = 0,
     nCutoff = 5,
     keepVariants = NULL,
@@ -4969,6 +5078,14 @@ summaryStatsQc <- function(
 ) {
     zMismatchQc <- arg_match(zMismatchQc)
     .ssqcCheckEntries(sumstats, mafCutoff, infoCutoff)
+    if (
+        !is.numeric(ldMafCutoff) ||
+            length(ldMafCutoff) != 1L ||
+            is.na(ldMafCutoff) ||
+            ldMafCutoff < 0
+    ) {
+        abort("summaryStatsQc: `ldMafCutoff` must be a single number >= 0.")
+    }
     p <- as.list(environment())
     opts <- .ssqcBuildOpts(p)
     res <- .ssqcRunEntries(sumstats, opts)

--- a/man/summaryStatsQc.Rd
+++ b/man/summaryStatsQc.Rd
@@ -9,6 +9,7 @@ summaryStatsQc(
   removeIndels = FALSE,
   removeStrandAmbiguous = TRUE,
   mafCutoff = 0,
+  ldMafCutoff = 0,
   infoCutoff = 0,
   nCutoff = 5,
   keepVariants = NULL,
@@ -45,7 +46,19 @@ and C/G strand-ambiguous variants. Default \code{TRUE}.}
 
 \item{mafCutoff}{Numeric (length 1). MAF threshold (variants with \code{MAF <
 mafCutoff} are dropped). Default 0. Requires \code{MAF} or \code{FRQ}
-column when non-zero.}
+column when non-zero. This is the \emph{study}-side filter, applied to the
+summary statistics' own MAF/FRQ; it is independent of \code{ldMafCutoff}.}
+
+\item{ldMafCutoff}{Numeric (length 1, >= 0). \emph{Reference-panel} MAF
+threshold. When \code{> 0}, panel variants whose panel MAF
+(\code{min(altFreq, 1 - altFreq)}) is below it are dropped from the LD
+reference \emph{before} the LD is materialized and before RAISS selects
+imputation targets, so a dropped variant is neither used in the LD nor
+imputed back. Panel frequencies are read from the panel's \code{.afreq}
+sidecar (no genotypes loaded); a panel without \code{.afreq} falls back to a
+single dosage pass. Default 0 (off), leaving existing callers
+byte-preserving. Independent of, and composes with, the study-side
+\code{mafCutoff}.}
 
 \item{infoCutoff}{Numeric (length 1). INFO score threshold. Default 0.
 Requires \code{INFO} column when non-zero.}

--- a/man/summaryStatsQc.Rd
+++ b/man/summaryStatsQc.Rd
@@ -9,7 +9,8 @@ summaryStatsQc(
   removeIndels = FALSE,
   removeStrandAmbiguous = TRUE,
   mafCutoff = 0,
-  ldMafCutoff = 0,
+  macCutoff = 0,
+  imissCutoff = 1,
   infoCutoff = 0,
   nCutoff = 5,
   keepVariants = NULL,
@@ -44,21 +45,19 @@ panel harmonization. Default \code{FALSE}.}
 \item{removeStrandAmbiguous}{Logical (length 1). When \code{TRUE}, drop A/T
 and C/G strand-ambiguous variants. Default \code{TRUE}.}
 
-\item{mafCutoff}{Numeric (length 1). MAF threshold (variants with \code{MAF <
-mafCutoff} are dropped). Default 0. Requires \code{MAF} or \code{FRQ}
-column when non-zero. This is the \emph{study}-side filter, applied to the
-summary statistics' own MAF/FRQ; it is independent of \code{ldMafCutoff}.}
+\item{mafCutoff}{Numeric (length 1). Minor-allele-frequency threshold,
+measured wherever it can be: against the summary statistics' own
+\code{AF} / \code{MAF} / \code{FRQ} column when one is present, and
+against the LD reference panel. Default 0 (off). See the panel-filters
+section below.}
 
-\item{ldMafCutoff}{Numeric (length 1, >= 0). \emph{Reference-panel} MAF
-threshold. When \code{> 0}, panel variants whose panel MAF
-(\code{min(altFreq, 1 - altFreq)}) is below it are dropped from the LD
-reference \emph{before} the LD is materialized and before RAISS selects
-imputation targets, so a dropped variant is neither used in the LD nor
-imputed back. Panel frequencies are read from the panel's \code{.afreq}
-sidecar (no genotypes loaded); a panel without \code{.afreq} falls back to a
-single dosage pass. Default 0 (off), leaving existing callers
-byte-preserving. Independent of, and composes with, the study-side
-\code{mafCutoff}.}
+\item{macCutoff}{Numeric (length 1). Minor-allele-count threshold for the
+LD reference panel, converted to a MAF equivalent using
+\code{macCutoff / (2 * nSamples)}; the stricter of it and
+\code{mafCutoff} applies. Default 0 (off).}
+
+\item{imissCutoff}{Numeric (length 1). Per-variant missingness-rate ceiling
+for the LD reference panel. Default 1 (off).}
 
 \item{infoCutoff}{Numeric (length 1). INFO score threshold. Default 0.
 Requires \code{INFO} column when non-zero.}
@@ -133,10 +132,14 @@ emits a warning and is skipped.)}
   \code{mafCutoff} and \code{macCutoff / (2 * nSamples)} applies, matching
   \code{\link{QtlDataset}}.
 
-  These bound what is \strong{imputed}, not what is kept: a variant present
-  in the sumstats survives whatever its frequency in the panel, both because
-  it is observed data and because RAISS derives its LD basis from those same
-  panel rows.}
+  These are a \strong{further} tightening applied to imputation targets
+  only, on top of the panel filter the top-level cutoffs already applied:
+  the panel handed to RAISS holds nothing below those. Use them to impute
+  only common variants from a panel deliberately kept wider than that ---
+  e.g. \code{mafCutoff = 0.001} with
+  \code{imputeOpts = list(mafCutoff = 0.01)}. A variant present in the
+  sumstats is never dropped here: RAISS derives its LD basis from those
+  same panel rows.}
 
 \item{matchMinProp}{Minimum proportion of LD panel variants that must be
 matched by the sumstats; default 0.}
@@ -193,11 +196,34 @@ audit record (variant counts, drop counts at each step, which filters fired,
 etc.). Fine-mapping and TWAS-weights pipelines reject SumStats inputs where
 \code{length(getQcInfo(x)) == 0L}.
 
-Column-availability error contract: a non-zero \code{mafCutoff} requires
-every entry to carry a \code{MAF} column; non-zero \code{infoCutoff} requires
-\code{INFO}; non-zero \code{nCutoff} requires \code{N}. Missing column with a
-non-zero cutoff is a hard error.
+Column-availability error contract: a non-zero \code{infoCutoff} requires
+every entry to carry an \code{INFO} column, and a non-zero \code{nCutoff}
+requires \code{N}; a missing column with a non-zero cutoff is a hard error.
+\code{mafCutoff} is exempt --- a study with no frequency column is still
+filtered against the reference panel (see below).
 }
+\section{Panel filters}{
+ \code{mafCutoff} / \code{macCutoff} /
+  \code{imissCutoff} are measured against the \strong{LD reference panel},
+  the same way \code{\link{fineMappingPipeline}} and
+  \code{\link{twasWeightsPipeline}} measure them on the RSS path, so one
+  number means the same thing wherever it is set. MAC is converted to a MAF
+  equivalent and the stricter of the two applies, matching
+  \code{\link{QtlDataset}}. Defaults (\code{0}, \code{0}, \code{1}) filter
+  nothing.
+
+  The panel is filtered once, before any entry is harmonized, so a variant
+  the panel cannot support is absent from the LD used by kriging,
+  SLALOM/DENTIST and RAISS, and is never an imputation target. Because
+  harmonization drops summary-statistic variants the panel does not cover,
+  this also \strong{discards observed variants} --- the intended behaviour:
+  a variant whose LD cannot be estimated is not usable downstream.
+
+  \code{mafCutoff} additionally filters the summary statistics' own
+  \code{AF} / \code{MAF} / \code{FRQ} column when one is present, so a
+  variant common in the panel but rare in the study is dropped as well.
+}
+
 \examples{
 data(gwasSumStatsS4Example)
 summaryStatsQc(gwasSumStatsS4Example)

--- a/tests/testthat/test_ctwasPipeline.R
+++ b/tests/testthat/test_ctwasPipeline.R
@@ -296,7 +296,7 @@ test_that("assembleCtwasInputs: accepts a QtlFineMappingResult weight source (to
     expect_equal(ifmr$weights[[1L]], itw$weights[[1L]])
 })
 
-test_that("assembleCtwasInputs: fits a boundary gene per-region but spans all its blocks", {
+test_that("assembleCtwasInputs: boundary gene fits per-region, spans all", {
     # Build two blocks with NON-OVERLAPPING GWAS variants. Block 1 covers
     # v1..v3, block 2 covers v4..v6. The gene's weight spans v2..v5 — i.e.
     # crosses the block boundary. With a per-block filter the gene would

--- a/tests/testthat/test_fineMappingPipeline.R
+++ b/tests/testthat/test_fineMappingPipeline.R
@@ -2217,10 +2217,10 @@ test_that("fineMappingPipeline(GwasSumStats): runs end-to-end with mocked RSS fi
     expect_setequal(getMethodNames(res), "susie")
 })
 
-test_that("fineMappingPipeline(GwasSumStats): threads per-variant N into postprocess (not the median, not 1)", {
+test_that("fineMappingPipeline(GwasSumStats): threads per-variant N", {
     # Regression for top_loci$N == 1. The RSS path must forward the per-variant
-    # effective N (the entry's N column, aligned to the analysed variants) to the
-    # post-processor -- NOT the scalar median the SuSiE-RSS fit consumes, and
+    # effective N (the entry's N column, aligned to the analysed variants) to
+    # the post-processor -- NOT the scalar median the SuSiE-RSS fit consumes,
     # never a list-collapsed 1.
     snp_ids <- sprintf("chr1:%d:A:G", 100L * (1:5))
     gr <- GenomicRanges::GRanges(
@@ -2230,7 +2230,8 @@ test_that("fineMappingPipeline(GwasSumStats): threads per-variant N into postpro
             width = 1L
         )
     )
-    perVarN <- c(1000L, 1100L, 1200L, 1300L, 1400L) # median = 1200, all distinct
+    # median = 1200, all distinct
+    perVarN <- c(1000L, 1100L, 1200L, 1300L, 1400L)
     S4Vectors::mcols(gr) <- S4Vectors::DataFrame(
         SNP = snp_ids,
         A1 = rep("A", 5L),

--- a/tests/testthat/test_fineMappingWrappers.R
+++ b/tests/testthat/test_fineMappingWrappers.R
@@ -1000,7 +1000,7 @@ test_that("buildTopLoci emits 22 columns in the fixed order on a non-empty fit",
     expect_equal(unique(out$method), "susie")
 })
 
-test_that("buildTopLoci: RSS per-variant N is threaded; list dataY never collapses to 1", {
+test_that("buildTopLoci: RSS per-variant N threads; list dataY isn't 1", {
     # Regression for top_loci$N == 1 on the RSS path: dataY = list(z = ...) made
     # as.matrix() collapse to a 1x1 cell, so nrow (and every N) was 1. The
     # per-variant effective N must instead be threaded into the N column.
@@ -1032,7 +1032,7 @@ test_that("buildTopLoci: RSS per-variant N is threaded; list dataY never collaps
     expect_equal(out$N[ord], perVarN)
     expect_false(any(out$N == 1L))
 
-    # (3b) list dataY + no n supplied -> N is NA (unknown), never the collapsed 1.
+    # (3b) list dataY + no n -> N is NA (unknown), never the collapsed 1.
     out_na <- buildTopLoci(
         fit = inp$fit,
         csTables = inp$cs_tables,

--- a/tests/testthat/test_ld.R
+++ b/tests/testthat/test_ld.R
@@ -4454,3 +4454,93 @@ test_that(".panelCutoffs short-circuits when no cutoff is set", {
     expect_equal(.panelCutoffs(list(mafCutoff = 0.01))$mafCutoff, 0.01)
     expect_equal(.panelCutoffs(list(imissCutoff = 0.5))$imissCutoff, 0.5)
 })
+
+
+# ---------------------------------------------------------------------------
+# .panelVariantFilter: the .afreq fast path
+#
+# Allele frequency alone answers MAF and MAC, so a panel that ships a PLINK2
+# .afreq sidecar is filtered without materializing its dosage. The sidecar and
+# the dosage must agree on every variant, or one pipeline would judge a
+# variant differently from the next.
+# ---------------------------------------------------------------------------
+
+# @noRd
+.pvfAfreqHandle <- function() {
+    readGenotypeHandle(test_path("test_data/test_variants"), format = "plink2")
+}
+
+test_that(".panelAfreqMaf reads panel MAF from the .afreq sidecar", {
+    skip_if_not_installed("pgenlibr")
+    handle <- .pvfAfreqHandle()
+    ids <- as.character(getSnpInfo(handle)$SNP)
+    maf <- .panelAfreqMaf(handle, ids)
+    afreq <- readAfreq(test_path("test_data/test_variants"))
+    altFreq <- afreq$alt_freq[match(ids, afreq$id)]
+    expect_equal(maf, pmin(altFreq, 1 - altFreq))
+})
+
+test_that(".panelAfreqMaf refuses a partial or non-plink2 sidecar", {
+    skip_if_not_installed("pgenlibr")
+    handle <- .pvfAfreqHandle()
+    ids <- as.character(getSnpInfo(handle)$SNP)
+    # One id the sidecar cannot answer for is enough: a partial answer would
+    # disagree with the dosage path about that variant, so NULL sends the
+    # caller down the dosage path for all of them.
+    expect_null(.panelAfreqMaf(handle, c(ids, "not-a-panel-variant")))
+    bed <- readGenotypeHandle(
+        test_path("test_data/test_variants"),
+        format = "plink1"
+    )
+    expect_null(.panelAfreqMaf(bed, as.character(getSnpInfo(bed)$SNP)))
+})
+
+test_that(".panelVariantFilter: .afreq and dosage agree on what to drop", {
+    skip_if_not_installed("pgenlibr")
+    handle <- .pvfAfreqHandle()
+    ids <- as.character(getSnpInfo(handle)$SNP)
+    viaAfreq <- .panelVariantFilter(handle, ids, mafCutoff = 0.2)
+    # Force the dosage path by hiding the sidecar from the fast path.
+    local_mocked_bindings(
+        .panelAfreqMaf = function(handle, variantIds) NULL,
+        .package = "pecotmr"
+    )
+    viaDosage <- .panelVariantFilter(handle, ids, mafCutoff = 0.2)
+    expect_lt(length(viaAfreq), length(ids))
+    expect_identical(viaAfreq, viaDosage)
+})
+
+test_that(".panelVariantFilter uses dosage whenever missingness is capped", {
+    skip_if_not_installed("pgenlibr")
+    # Missingness is not derivable from the sidecar, so an imissCutoff must
+    # never be silently answered by it.
+    handle <- .pvfAfreqHandle()
+    ids <- as.character(getSnpInfo(handle)$SNP)
+    local_mocked_bindings(
+        .panelAfreqMaf = function(handle, variantIds) {
+            abort("the .afreq fast path must not run here")
+        },
+        .package = "pecotmr"
+    )
+    expect_no_error(
+        .panelVariantFilter(handle, ids, mafCutoff = 0.2, imissCutoff = 0.5)
+    )
+})
+
+test_that(".panelAfreqPrefixes reads only the chromosomes the panel spans", {
+    handle <- .pvfAfreqHandle()
+    # Single-file panel: its own stem, resolved for file access.
+    expect_identical(
+        .panelAfreqPrefixes(handle),
+        pecotmr:::.genotypeReadPath(handle)
+    )
+    # Sharded panel: a manifest chromosome the snpInfo does not span is not
+    # read -- the cost per-chromosome sketch trimming exists to avoid.
+    sharded <- handle
+    sharded@chromPaths <- c(
+        "22" = getPath(handle),
+        "21" = "/nonexistent/chr21"
+    )
+    sharded@snpInfo$CHR <- rep("22", nrow(getSnpInfo(handle)))
+    expect_identical(.panelAfreqPrefixes(sharded), getPath(handle))
+})

--- a/tests/testthat/test_sumstatsQc.R
+++ b/tests/testthat/test_sumstatsQc.R
@@ -7300,6 +7300,111 @@ test_that(".subsetSketchToRange / .subsetSketchToIds are NULL-safe", {
 
 
 # ---------------------------------------------------------------------------
+# summaryStatsQc ldMafCutoff: reference-panel MAF filter (before LD / RAISS)
+# ---------------------------------------------------------------------------
+
+.ldmaf_handle <- function() {
+    readGenotypeHandle(
+        test_path("test_data/test_variants"),
+        format = "plink2"
+    )
+}
+
+test_that(".panelAltFreqFromAfreq reads panel AF from .afreq (no genotypes)", {
+    skip_if_not_installed("pgenlibr")
+    h <- .ldmaf_handle()
+    ids <- as.character(getSnpInfo(h)$SNP)
+    af <- pecotmr:::.panelAltFreqFromAfreq(h, ids)
+    expect_false(is.null(af))
+    expect_length(af, length(ids))
+    expect_true(all(af >= 0 & af <= 1, na.rm = TRUE))
+    # Exactly the .afreq file's alt_freq, aligned by id -- computed without any
+    # genotype read (readAfreq only touches the .afreq sidecar).
+    afreq <- readAfreq(test_path("test_data/test_variants"))
+    expect_equal(af, afreq$alt_freq[match(ids, afreq$id)])
+})
+
+test_that(".ssqcPanelMafPrune drops exactly the sub-cutoff panel variants (afreq path)", {
+    skip_if_not_installed("pgenlibr")
+    h <- .ldmaf_handle()
+    ids <- as.character(getSnpInfo(h)$SNP)
+    maf <- pmin(
+        pecotmr:::.panelAltFreqFromAfreq(h, ids),
+        1 - pecotmr:::.panelAltFreqFromAfreq(h, ids)
+    )
+    cutoff <- stats::median(maf, na.rm = TRUE)
+    pruned <- pecotmr:::.ssqcPanelMafPrune(h, cutoff, "test")
+    keptIds <- as.character(getSnpInfo(pruned)$SNP)
+    expect_lt(length(keptIds), length(ids)) # some dropped
+    # kept == exactly the variants at/above the cutoff; dropped == below.
+    expect_setequal(keptIds, ids[!is.na(maf) & maf >= cutoff])
+    expect_true(all(maf[match(keptIds, ids)] >= cutoff))
+})
+
+test_that(".ssqcPanelMafPrune is a byte-preserving no-op at cutoff 0 / NULL", {
+    h <- .ldmaf_handle()
+    expect_identical(pecotmr:::.ssqcPanelMafPrune(h, 0, "test"), h)
+    expect_identical(pecotmr:::.ssqcPanelMafPrune(h, NULL, "test"), h)
+    expect_null(pecotmr:::.ssqcPanelMafPrune(NULL, 0.01, "test"))
+})
+
+test_that(".ssqcPanelMafPrune falls back to a dosage pass when no .afreq exists", {
+    skip_if_not_installed("pgenlibr")
+    h <- .ldmaf_handle()
+    ids <- as.character(getSnpInfo(h)$SNP)
+    # A cutoff inside the panel's MAF range (0.055-0.5 on this fixture) so the
+    # dosage fallback actually drops variants.
+    maf <- pmin(
+        pecotmr:::.panelAltFreqFromAfreq(h, ids),
+        1 - pecotmr:::.panelAltFreqFromAfreq(h, ids)
+    )
+    cutoff <- stats::median(maf, na.rm = TRUE)
+    # Force the afreq path to report "no .afreq available" so the dosage-derived
+    # .panelVariantFilter path runs instead. The two must agree on what to drop.
+    local_mocked_bindings(
+        .panelAltFreqFromAfreq = function(handle, ids) NULL,
+        .package = "pecotmr"
+    )
+    pruned <- pecotmr:::.ssqcPanelMafPrune(h, cutoff, "test")
+    keptIds <- as.character(getSnpInfo(pruned)$SNP)
+    expect_lt(length(keptIds), length(ids))
+    expect_setequal(
+        keptIds,
+        pecotmr:::.panelVariantFilter(h, ids, mafCutoff = cutoff)
+    )
+})
+
+test_that(".ssqcPanelMafPrune prunes the RSE sketch's seed handle, not just the row view", {
+    skip_if_not_installed("pgenlibr")
+    # A summaryStatsQc ldSketch is an RSE wrapping the GenotypeHandle; harmonize,
+    # kriging, mismatch-QC and RAISS all read the panel through .ldSketchHandle()
+    # (the dosage DelayedArray's seed handle). Subsetting the RSE rows leaves that
+    # seed carrying the full panel, so the prune MUST reach the seed handle -- this
+    # is the real-flow shape the bare-handle tests above do not exercise.
+    h <- .ldmaf_handle()
+    ids <- as.character(getSnpInfo(h)$SNP)
+    maf <- pmin(
+        pecotmr:::.panelAltFreqFromAfreq(h, ids),
+        1 - pecotmr:::.panelAltFreqFromAfreq(h, ids)
+    )
+    cutoff <- stats::median(maf, na.rm = TRUE)
+    rse <- pecotmr:::.genotypeExperiment(h)
+    expect_s4_class(rse, "RangedSummarizedExperiment")
+    pruned <- pecotmr:::.ssqcPanelMafPrune(rse, cutoff, "test")
+    seedIds <- as.character(getSnpInfo(pecotmr:::.ldSketchHandle(pruned))$SNP)
+    expect_lt(length(seedIds), length(ids))
+    expect_setequal(seedIds, ids[!is.na(maf) & maf >= cutoff])
+})
+
+test_that("summaryStatsQc validates ldMafCutoff (before any panel read)", {
+    ss <- .ssQ_makeGwasSumStats()
+    expect_error(summaryStatsQc(ss, ldMafCutoff = -1), "ldMafCutoff")
+    expect_error(summaryStatsQc(ss, ldMafCutoff = c(0.01, 0.02)), "ldMafCutoff")
+    expect_error(summaryStatsQc(ss, ldMafCutoff = NA_real_), "ldMafCutoff")
+})
+
+
+# ---------------------------------------------------------------------------
 # RAISS imputation: MAF / MAC / missingness cutoffs
 #
 # Without these, every rare variant in the window of a large LD sketch becomes

--- a/tests/testthat/test_sumstatsQc.R
+++ b/tests/testthat/test_sumstatsQc.R
@@ -3130,8 +3130,15 @@ test_that("summaryStatsQc: rejects non-SumStats input", {
 
 test_that("mafCutoff > 0 with no frequency skips the filter, not the run", {
     # A frequency-less study can still run under a default mafCutoff: the
-    # filter is skipped with one warning rather than aborting the pipeline.
+    # STUDY-side filter is skipped with one warning rather than aborting the
+    # pipeline. The panel side still runs (mafCutoff is measured wherever it
+    # can be), so the mock extractor stands in for the sketch's dosage; every
+    # mocked variant sits near MAF 0.3, so nothing is dropped there.
     ss <- .ssQ_makeGwasSumStats()
+    local_mocked_bindings(
+        extractBlockGenotypes = .ssQ_mockExtractor(),
+        .package = "pecotmr"
+    )
     expect_warning(
         res <- summaryStatsQc(ss, mafCutoff = 0.05),
         "skipping the MAF filter"
@@ -6973,6 +6980,13 @@ test_that("summaryStatsQc: per-entry rollup enumerates every removed-step segmen
         genome = "hg19",
         ldSketch = .ssQ_makeHandle()
     )
+    # mafCutoff is measured against the panel too, so the fabricated sketch
+    # needs a dosage source; the mock puts every variant near MAF 0.3, well
+    # clear of the 0.01 cutoff, leaving the audited drop counts study-side.
+    local_mocked_bindings(
+        extractBlockGenotypes = .ssQ_mockExtractor(),
+        .package = "pecotmr"
+    )
     msgs <- capture_messages(
         res <- summaryStatsQc(
             ss,
@@ -7300,107 +7314,158 @@ test_that(".subsetSketchToRange / .subsetSketchToIds are NULL-safe", {
 
 
 # ---------------------------------------------------------------------------
-# summaryStatsQc ldMafCutoff: reference-panel MAF filter (before LD / RAISS)
+# summaryStatsQc panel filters: mafCutoff / macCutoff / imissCutoff measured
+# against the LD reference panel, applied before any entry is harmonized.
 # ---------------------------------------------------------------------------
 
-.ldmaf_handle <- function() {
-    readGenotypeHandle(
-        test_path("test_data/test_variants"),
-        format = "plink2"
+.ssqcPanelStem <- function() {
+    test_path("test_data/test_variants")
+}
+
+.ssqcPanelHandle <- function() {
+    readGenotypeHandle(.ssqcPanelStem(), format = "plink2")
+}
+
+# Panel MAF straight from the .afreq sidecar, aligned to the handle's snpInfo
+# order -- the ground truth the filter is checked against.
+.ssqcPanelMaf <- function(handle) {
+    afreq <- readAfreq(.ssqcPanelStem())
+    ids <- as.character(getSnpInfo(handle)$SNP)
+    altFreq <- afreq$alt_freq[match(ids, afreq$id)]
+    pmin(altFreq, 1 - altFreq)
+}
+
+# A GwasSumStats over every panel variant, each carrying a study AF of 0.30 --
+# common in the study whatever the panel says, so only a panel-side filter can
+# remove it.
+.ssqcPanelSumStats <- function(handle) {
+    si <- getSnpInfo(handle)
+    gr <- GenomicRanges::GRanges(
+        seqnames = paste0("chr", si$CHR),
+        ranges = IRanges::IRanges(start = as.integer(si$BP), width = 1L)
+    )
+    set.seed(11)
+    S4Vectors::mcols(gr) <- S4Vectors::DataFrame(
+        SNP = si$SNP,
+        A1 = si$A1,
+        A2 = si$A2,
+        Z = stats::rnorm(nrow(si)),
+        N = rep(10000, nrow(si)),
+        AF = rep(0.30, nrow(si))
+    )
+    GwasSumStats(
+        study = "g1",
+        entry = list(gr),
+        genome = "hg19",
+        ldSketch = handle
     )
 }
 
-test_that(".panelAltFreqFromAfreq reads panel AF from .afreq (no genotypes)", {
+test_that(".ssqcPrunePanel drops exactly the sub-cutoff panel variants", {
     skip_if_not_installed("pgenlibr")
-    h <- .ldmaf_handle()
+    h <- .ssqcPanelHandle()
     ids <- as.character(getSnpInfo(h)$SNP)
-    af <- pecotmr:::.panelAltFreqFromAfreq(h, ids)
-    expect_false(is.null(af))
-    expect_length(af, length(ids))
-    expect_true(all(af >= 0 & af <= 1, na.rm = TRUE))
-    # Exactly the .afreq file's alt_freq, aligned by id -- computed without any
-    # genotype read (readAfreq only touches the .afreq sidecar).
-    afreq <- readAfreq(test_path("test_data/test_variants"))
-    expect_equal(af, afreq$alt_freq[match(ids, afreq$id)])
-})
-
-test_that(".ssqcPanelMafPrune drops exactly the sub-cutoff panel variants (afreq path)", {
-    skip_if_not_installed("pgenlibr")
-    h <- .ldmaf_handle()
-    ids <- as.character(getSnpInfo(h)$SNP)
-    maf <- pmin(
-        pecotmr:::.panelAltFreqFromAfreq(h, ids),
-        1 - pecotmr:::.panelAltFreqFromAfreq(h, ids)
-    )
+    maf <- .ssqcPanelMaf(h)
     cutoff <- stats::median(maf, na.rm = TRUE)
-    pruned <- pecotmr:::.ssqcPanelMafPrune(h, cutoff, "test")
-    keptIds <- as.character(getSnpInfo(pruned)$SNP)
-    expect_lt(length(keptIds), length(ids)) # some dropped
-    # kept == exactly the variants at/above the cutoff; dropped == below.
-    expect_setequal(keptIds, ids[!is.na(maf) & maf >= cutoff])
-    expect_true(all(maf[match(keptIds, ids)] >= cutoff))
-})
-
-test_that(".ssqcPanelMafPrune is a byte-preserving no-op at cutoff 0 / NULL", {
-    h <- .ldmaf_handle()
-    expect_identical(pecotmr:::.ssqcPanelMafPrune(h, 0, "test"), h)
-    expect_identical(pecotmr:::.ssqcPanelMafPrune(h, NULL, "test"), h)
-    expect_null(pecotmr:::.ssqcPanelMafPrune(NULL, 0.01, "test"))
-})
-
-test_that(".ssqcPanelMafPrune falls back to a dosage pass when no .afreq exists", {
-    skip_if_not_installed("pgenlibr")
-    h <- .ldmaf_handle()
-    ids <- as.character(getSnpInfo(h)$SNP)
-    # A cutoff inside the panel's MAF range (0.055-0.5 on this fixture) so the
-    # dosage fallback actually drops variants.
-    maf <- pmin(
-        pecotmr:::.panelAltFreqFromAfreq(h, ids),
-        1 - pecotmr:::.panelAltFreqFromAfreq(h, ids)
+    pruned <- expect_message(
+        pecotmr:::.ssqcPrunePanel(
+            h,
+            list(mafCutoff = cutoff, macCutoff = 0, imissCutoff = 1),
+            "test"
+        ),
+        "below the LD-panel MAF / MAC / missingness cutoffs"
     )
-    cutoff <- stats::median(maf, na.rm = TRUE)
-    # Force the afreq path to report "no .afreq available" so the dosage-derived
-    # .panelVariantFilter path runs instead. The two must agree on what to drop.
-    local_mocked_bindings(
-        .panelAltFreqFromAfreq = function(handle, ids) NULL,
-        .package = "pecotmr"
-    )
-    pruned <- pecotmr:::.ssqcPanelMafPrune(h, cutoff, "test")
     keptIds <- as.character(getSnpInfo(pruned)$SNP)
     expect_lt(length(keptIds), length(ids))
-    expect_setequal(
-        keptIds,
-        pecotmr:::.panelVariantFilter(h, ids, mafCutoff = cutoff)
-    )
+    expect_setequal(keptIds, ids[!is.na(maf) & maf >= cutoff])
 })
 
-test_that(".ssqcPanelMafPrune prunes the RSE sketch's seed handle, not just the row view", {
+test_that(".ssqcPrunePanel is a no-op with no cutoffs / a NULL sketch", {
+    h <- .ssqcPanelHandle()
+    expect_identical(pecotmr:::.ssqcPrunePanel(h, NULL, "test"), h)
+    cutoffs <- list(mafCutoff = 0, macCutoff = 0, imissCutoff = 1)
+    expect_identical(pecotmr:::.ssqcPrunePanel(h, cutoffs, "test"), h)
+    expect_null(pecotmr:::.ssqcPrunePanel(NULL, cutoffs, "test"))
+})
+
+test_that(".ssqcPrunePanel prunes the RSE sketch's seed handle, not the view", {
     skip_if_not_installed("pgenlibr")
-    # A summaryStatsQc ldSketch is an RSE wrapping the GenotypeHandle; harmonize,
-    # kriging, mismatch-QC and RAISS all read the panel through .ldSketchHandle()
-    # (the dosage DelayedArray's seed handle). Subsetting the RSE rows leaves that
-    # seed carrying the full panel, so the prune MUST reach the seed handle -- this
-    # is the real-flow shape the bare-handle tests above do not exercise.
-    h <- .ldmaf_handle()
+    # A summaryStatsQc ldSketch is an RSE wrapping the GenotypeHandle;
+    # harmonization, kriging, mismatch-QC and RAISS all read the panel through
+    # .ldSketchHandle() (the dosage DelayedArray's seed). Subsetting the RSE
+    # rows leaves that seed carrying the full panel, so the prune must reach
+    # the seed -- the real-flow shape the bare-handle tests do not exercise.
+    h <- .ssqcPanelHandle()
+    maf <- .ssqcPanelMaf(h)
     ids <- as.character(getSnpInfo(h)$SNP)
-    maf <- pmin(
-        pecotmr:::.panelAltFreqFromAfreq(h, ids),
-        1 - pecotmr:::.panelAltFreqFromAfreq(h, ids)
-    )
     cutoff <- stats::median(maf, na.rm = TRUE)
     rse <- pecotmr:::.genotypeExperiment(h)
     expect_s4_class(rse, "RangedSummarizedExperiment")
-    pruned <- pecotmr:::.ssqcPanelMafPrune(rse, cutoff, "test")
-    seedIds <- as.character(getSnpInfo(pecotmr:::.ldSketchHandle(pruned))$SNP)
-    expect_lt(length(seedIds), length(ids))
-    expect_setequal(seedIds, ids[!is.na(maf) & maf >= cutoff])
+    pruned <- suppressMessages(pecotmr:::.ssqcPrunePanel(
+        rse,
+        list(mafCutoff = cutoff, macCutoff = 0, imissCutoff = 1),
+        "test"
+    ))
+    seed <- pecotmr:::.ldSketchHandle(pruned)
+    expect_setequal(
+        as.character(getSnpInfo(seed)$SNP),
+        ids[!is.na(maf) & maf >= cutoff]
+    )
 })
 
-test_that("summaryStatsQc validates ldMafCutoff (before any panel read)", {
+test_that("summaryStatsQc: mafCutoff drops panel-rare observed variants", {
+    skip_if_not_installed("pgenlibr")
+    # Regression for the study-side-only filter: every variant here has study
+    # AF 0.30, so nothing the sumstats' own frequency column can say would
+    # remove it. The panel must be what decides.
+    h <- .ssqcPanelHandle()
+    maf <- .ssqcPanelMaf(h)
+    cutoff <- stats::median(maf, na.rm = TRUE)
+    ss <- .ssqcPanelSumStats(h)
+    out <- suppressMessages(summaryStatsQc(ss, mafCutoff = cutoff, nCutoff = 0))
+    entry <- pecotmr:::.collectionEntry(out, 1)
+    expect_equal(length(entry), sum(!is.na(maf) & maf >= cutoff))
+    # ... and the panel carried on the result -- the seed handle every LD
+    # read keys off, not just the row view -- holds no sub-cutoff variant.
+    seed <- pecotmr:::.ldSketchHandle(getLdSketch(out))
+    keptMaf <- maf[match(
+        as.character(getSnpInfo(seed)$SNP),
+        as.character(getSnpInfo(h)$SNP)
+    )]
+    expect_true(all(keptMaf >= cutoff))
+})
+
+test_that("summaryStatsQc: macCutoff is the stricter of MAF / MAC", {
+    skip_if_not_installed("pgenlibr")
+    h <- .ssqcPanelHandle()
+    maf <- .ssqcPanelMaf(h)
+    ss <- .ssqcPanelSumStats(h)
+    # MAC expressed per panel sample: 2 * nSamples * mafEquivalent.
+    cutoff <- stats::median(maf, na.rm = TRUE)
+    mac <- ceiling(cutoff * 2 * getNSamples(h))
+    out <- suppressMessages(summaryStatsQc(ss, macCutoff = mac, nCutoff = 0))
+    entry <- pecotmr:::.collectionEntry(out, 1)
+    expected <- sum(!is.na(maf) & maf >= mac / (2 * getNSamples(h)))
+    expect_equal(length(entry), expected)
+})
+
+test_that("summaryStatsQc: the panel filter is off by default", {
+    skip_if_not_installed("pgenlibr")
+    h <- .ssqcPanelHandle()
+    ss <- .ssqcPanelSumStats(h)
+    out <- suppressMessages(summaryStatsQc(ss, nCutoff = 0))
+    expect_equal(
+        length(pecotmr:::.collectionEntry(out, 1)),
+        nrow(getSnpInfo(h))
+    )
+})
+
+test_that("summaryStatsQc validates the panel cutoffs before any panel read", {
     ss <- .ssQ_makeGwasSumStats()
-    expect_error(summaryStatsQc(ss, ldMafCutoff = -1), "ldMafCutoff")
-    expect_error(summaryStatsQc(ss, ldMafCutoff = c(0.01, 0.02)), "ldMafCutoff")
-    expect_error(summaryStatsQc(ss, ldMafCutoff = NA_real_), "ldMafCutoff")
+    expect_error(summaryStatsQc(ss, mafCutoff = -1), "mafCutoff")
+    expect_error(summaryStatsQc(ss, macCutoff = c(1, 2)), "macCutoff")
+    expect_error(summaryStatsQc(ss, imissCutoff = NA_real_), "imissCutoff")
+    expect_error(summaryStatsQc(ss, macCutoff = Inf), "macCutoff")
 })
 
 
@@ -7598,14 +7663,18 @@ test_that("summaryStatsQc imputeOpts cutoffs bound what RAISS imputes", {
     refPanel <- frame(panelIds)
     knownZ <- if (length(knownIds) == 0L) {
         data.frame(
-            chrom = character(0), pos = integer(0),
-            variant_id = character(0), stringsAsFactors = FALSE
+            chrom = character(0),
+            pos = integer(0),
+            variant_id = character(0),
+            stringsAsFactors = FALSE
         )
     } else {
         frame(knownIds)
     }
     panelIds[.raissUnknownIdx(
-        refPanel, knownZ, intersect(knownIds, panelIds)
+        refPanel,
+        knownZ,
+        intersect(knownIds, panelIds)
     )]
 }
 
@@ -7631,7 +7700,8 @@ test_that("a flip pair is excluded even when nothing is known there", {
     # happen to carry.
     got <- .raiss_targets(character(0))
     expect_false(any(is_in(
-        normalizeVariantId(c("chr1:100:A:AT", "chr1:100:AT:A")), got
+        normalizeVariantId(c("chr1:100:A:AT", "chr1:100:AT:A")),
+        got
     )))
 })
 
@@ -7673,16 +7743,24 @@ test_that(".raissFlipPairMask needs both orientations, not just an indel", {
             chrom = rep("1", 5),
             pos = c(100L, 100L, 200L, 300L, 300L),
             variant_id = c(
-                "1:100:A:G", "1:100:A:T", "1:200:A:G",
-                "1:300:A:G", "1:300:A:T"
+                "1:100:A:G",
+                "1:100:A:T",
+                "1:200:A:G",
+                "1:300:A:G",
+                "1:300:A:T"
             ),
             A1 = c("G", "T", "G", "G", "T"),
             A2 = rep("A", 5),
             stringsAsFactors = FALSE
         ),
         knownZ = data.frame(
-            chrom = "1", pos = 100L, variant_id = "1:100:A:G",
-            A1 = "G", A2 = "A", z = 3.0, stringsAsFactors = FALSE
+            chrom = "1",
+            pos = 100L,
+            variant_id = "1:100:A:G",
+            A1 = "G",
+            A2 = "A",
+            z = 3.0,
+            stringsAsFactors = FALSE
         )
     )
 }
@@ -7746,7 +7824,8 @@ test_that("raissSingleMatrix does not impute at a typed position", {
     imp <- setdiff(r$resultNofilter$variant_id, d$knownZ$variant_id)
     expect_false(is_in("1:100:A:T", imp))
     expect_true(all(is_in(
-        c("1:200:A:G", "1:300:A:G", "1:300:A:T"), imp
+        c("1:200:A:G", "1:300:A:G", "1:300:A:T"),
+        imp
     )))
     expect_true(is_in("1:100:A:G", r$resultNofilter$variant_id))
 })
@@ -7827,8 +7906,13 @@ test_that(".subsetSketchToIds keeps the panel when ids are unextractable", {
 
 .afm_df <- function(freqcol, val) {
     d <- data.frame(
-        chrom = "chr1", pos = 100L, variant_id = "chr1:100:A:G",
-        A1 = "A", A2 = "G", z = 2.5, n_sample = 1000,
+        chrom = "chr1",
+        pos = 100L,
+        variant_id = "chr1:100:A:G",
+        A1 = "A",
+        A2 = "G",
+        z = 2.5,
+        n_sample = 1000,
         stringsAsFactors = FALSE
     )
     d[[freqcol]] <- val
@@ -7837,8 +7921,14 @@ test_that(".subsetSketchToIds keeps the panel when ids are unextractable", {
 
 .afm_cm <- function(...) {
     c(
-        chrom = "chrom", pos = "pos", variant_id = "variant_id",
-        A1 = "A1", A2 = "A2", z = "z", n_sample = "n_sample", ...
+        chrom = "chrom",
+        pos = "pos",
+        variant_id = "variant_id",
+        A1 = "A1",
+        A2 = "A2",
+        z = "z",
+        n_sample = "n_sample",
+        ...
     )
 }
 
@@ -7846,13 +7936,15 @@ test_that("an af: key is directional AF; a maf: key is directionless", {
     # Same source column, different declaration -> different meaning.
     a <- suppressWarnings(.resolveSumstatCols(
         .afm_df("effect_allele_frequency", 0.8),
-        .afm_cm(af = "effect_allele_frequency"), "af"
+        .afm_cm(af = "effect_allele_frequency"),
+        "af"
     ))
     expect_equal(a$AF, 0.8)
     expect_null(a$MAF)
     b <- suppressWarnings(.resolveSumstatCols(
         .afm_df("effect_allele_frequency", 0.8),
-        .afm_cm(maf = "effect_allele_frequency"), "maf"
+        .afm_cm(maf = "effect_allele_frequency"),
+        "maf"
     ))
     expect_null(b$AF)
     expect_equal(b$MAF, 0.8)
@@ -7861,7 +7953,9 @@ test_that("an af: key is directional AF; a maf: key is directionless", {
 test_that("an undeclared af warns distinctly and yields no AF column", {
     expect_warning(
         out <- .resolveSumstatCols(
-            .afm_df("maf", 0.2), .afm_cm(maf = "maf"), "undeclared"
+            .afm_df("maf", 0.2),
+            .afm_cm(maf = "maf"),
+            "undeclared"
         ),
         "no effect-allele frequency declared"
     )
@@ -7872,7 +7966,9 @@ test_that("a declared-but-unusable af warns with a different message", {
     # Distinct from "undeclared": this is a data problem, not a mapping one.
     expect_warning(
         .resolveSumstatCols(
-            .afm_df("eaf", NA_real_), .afm_cm(af = "eaf"), "missing"
+            .afm_df("eaf", NA_real_),
+            .afm_cm(af = "eaf"),
+            "missing"
         ),
         "declared but its values are all missing"
     )
@@ -7881,7 +7977,9 @@ test_that("a declared-but-unusable af warns with a different message", {
 test_that(".fmAfByVar reads AF, and is NULL when af was never declared", {
     mk <- function(cm) {
         .dfToEntryGranges(suppressWarnings(.resolveSumstatCols(
-            .afm_df("effect_allele_frequency", 0.8), cm, "lbl"
+            .afm_df("effect_allele_frequency", 0.8),
+            cm,
+            "lbl"
         )))
     }
     gA <- mk(.afm_cm(af = "effect_allele_frequency"))
@@ -7904,17 +8002,31 @@ test_that("an allele swap complements af but leaves the directionless maf", {
     # af -> 1 - af on a swap; maf = min(af, 1-af) is swap-invariant, so
     # complementing it would corrupt it.
     tgt <- data.frame(
-        chrom = "1", pos = 100L, A2 = "G", A1 = "A", SNP = "v1",
-        Z = 2.0, AF = 0.8, MAF = 0.2, stringsAsFactors = FALSE
+        chrom = "1",
+        pos = 100L,
+        A2 = "G",
+        A1 = "A",
+        SNP = "v1",
+        Z = 2.0,
+        AF = 0.8,
+        MAF = 0.2,
+        stringsAsFactors = FALSE
     )
     ref <- data.frame(
-        chrom = "1", pos = 100L, A2 = "A", A1 = "G",
-        variant_id = "v1", stringsAsFactors = FALSE
+        chrom = "1",
+        pos = 100L,
+        A2 = "A",
+        A1 = "G",
+        variant_id = "v1",
+        stringsAsFactors = FALSE
     )
     h <- harmonizeAlleles(
-        tgt, ref,
-        colToFlip = "Z", colToComplement = "AF",
-        matchMinProp = 0, removeStrandAmbiguous = FALSE
+        tgt,
+        ref,
+        colToFlip = "Z",
+        colToComplement = "AF",
+        matchMinProp = 0,
+        removeStrandAmbiguous = FALSE
     )$harmonizedData
     expect_equal(h$AF, 0.2)
     expect_equal(h$Z, -2.0)


### PR DESCRIPTION
`summaryStatsQc()` gains `ldMafCutoff` (default 0). When `> 0`, panel variants whose panel MAF (`min(altFreq, 1 - altFreq)`) is below the cutoff are dropped from the LD reference **before** the LD is materialized and before RAISS selects imputation targets, so a dropped variant is neither used in the LD nor imputed back.

- Frequencies read from the panel's `.afreq` via `readAfreq()` (no genotypes loaded); the sketch's seed `GenotypeHandle` is pruned up front, so only the retained panel's LD is ever read. A panel without `.afreq` falls back to a single dosage pass.
- Default 0 is a byte-preserving no-op; independent of, and composes with, the study-side `mafCutoff`.

Validated on a real chr21 AD_Bellenguez block: with `ldMafCutoff = 0.005` and `impute = TRUE`, 0 variants with panel MAF < 0.005 are imputed (vs 1115 with the filter off) and the final LD sketch has none below the cutoff; fine-mapping runs end-to-end with common-variant max|PIP diff| = 0.0025, and the filtered run is faster. New unit tests in `test_sumstatsQc.R`, including one that prunes the RSE sketch's seed handle.