### PR TITLE
Preserve observed-variant AF through the RAISS merge

### DIFF
--- a/R/sumstatsQc.R
+++ b/R/sumstatsQc.R
@@ -3997,6 +3997,15 @@ krigingOutlierQc <- function(
     if (is_in("se", colnames(impDf))) {
         out$SE <- impDf$se
     }
+    # RAISS reconstructs the z-score only, so it has no frequency for an imputed
+    # variant. But the OBSERVED variants came in with a (harmonized, directional)
+    # AF, which the rebuilt `out` above would otherwise discard -- leaving
+    # top_loci$af NA for the whole entry under --impute. Re-attach it by SNP so
+    # observed variants keep their AF and imputed variants (absent from `df`) get
+    # NA. No-op when the study declared no frequency.
+    if (is_in("AF", colnames(df))) {
+        out$AF <- as.numeric(df$AF)[match(out$SNP, df$SNP)]
+    }
     if (is_in("N", colnames(out)) && any(is.na(out$N))) {
         out$N[is.na(out$N)] <- stats::median(out$N, na.rm = TRUE)
     }

--- a/tests/testthat/test_sumstatsQc.R
+++ b/tests/testthat/test_sumstatsQc.R
@@ -6402,6 +6402,57 @@ test_that("raiss genotypeMatrix path: single-matrix, list, all-fail, and bad-typ
 })
 
 # ===========================================================================
+# .qcRaissMerge: observed-variant AF is preserved through the RAISS merge
+# ===========================================================================
+
+# RAISS reconstructs z only; the merge rebuilds the entry from its output and
+# used to drop AF entirely, so --impute left top_loci$af NA for the whole entry.
+# The observed variants' (harmonized) AF must survive; imputed variants get NA.
+.raissMergeInputs <- function(withAf = TRUE) {
+    obs <- c("chr1:100:A:G", "chr1:200:C:T", "chr1:300:A:T")
+    imp <- c("chr1:150:A:G", "chr1:250:C:T")
+    df <- tibble(
+        SNP = obs,
+        A1 = c("G", "T", "T"),
+        A2 = c("A", "C", "A"),
+        Z = c(1.2, -0.8, 2.1),
+        N = c(1000L, 1000L, 1000L)
+    )
+    if (withAf) {
+        # A post-harmonization (directional) AF -- what the merge must re-attach.
+        df$AF <- c(0.10, 0.25, 0.40)
+    }
+    impDf <- data.frame(
+        chrom = rep("1", 5L),
+        pos = c(100L, 200L, 300L, 150L, 250L),
+        variant_id = c(obs, imp),
+        A1 = c("G", "T", "T", "G", "T"),
+        A2 = c("A", "C", "A", "A", "C"),
+        z = c(1.2, -0.8, 2.1, 0.5, -0.3),
+        n = rep(1000L, 5L),
+        stringsAsFactors = FALSE
+    )
+    list(imputed = list(resultFilter = impDf), knownZ = df["SNP"], df = df,
+         obs = obs, imp = imp)
+}
+
+test_that(".qcRaissMerge preserves observed AF and leaves imputed AF NA", {
+    f <- .raissMergeInputs(withAf = TRUE)
+    out <- pecotmr:::.qcRaissMerge(f$imputed, f$knownZ, f$df)$df
+    expect_true("AF" %in% colnames(out))
+    # observed variants keep exactly their pre-imputation (harmonized) AF
+    expect_equal(out$AF[match(f$obs, out$SNP)], c(0.10, 0.25, 0.40))
+    # imputed variants -- absent from df, no frequency from RAISS -- are NA
+    expect_true(all(is.na(out$AF[match(f$imp, out$SNP)])))
+})
+
+test_that(".qcRaissMerge adds no AF column when the study declared none", {
+    f <- .raissMergeInputs(withAf = FALSE)
+    out <- pecotmr:::.qcRaissMerge(f$imputed, f$knownZ, f$df)$df
+    expect_false("AF" %in% colnames(out))
+})
+
+# ===========================================================================
 # raiss: multi-LD-block verbose / merge / error branches
 # ===========================================================================
 


### PR DESCRIPTION
`summaryStatsQc(impute = TRUE)`: `.qcRaissMerge` rebuilt the entry from the RAISS output keeping only `chrom/pos/SNP/A1/A2/Z` (+N/BETA/SE), dropping `AF` for **every** variant — so `top_loci$af` was NA across the whole entry whenever imputation was on, even with `af:` declared.

Re-attach the observed variants' (harmonized, directional) `AF` from the pre-imputation `df` by `SNP`; imputed variants — which RAISS reconstructs the z-score only for — get `NA`. No-op when no frequency was declared. Reporting-only: `susie_rss` never reads `af`, so PIP / credible sets are unchanged.

Validated on real chr21 AD_Bellenguez: under `--impute` all 7380 observed variants keep their AF (equal to the no-impute run) and the 458 imputed are NA; `top_loci$af` is now populated on observed variants (was all NA). New unit tests in `test_sumstatsQc.R`.