### PR TITLE
Drop GWAS variants on uninterpretable-id LD-panel entries

### DIFF
--- a/R/sumstatsQc.R
+++ b/R/sumstatsQc.R
@@ -3156,6 +3156,26 @@ krigingOutlierQc <- function(
 # harmonizeAlleles against the ldSketch's variant info. Threads the
 # variant-level filters (indels, strand-ambiguous, duplicates) through
 # so the LD-panel-anchored pass handles them in a single sweep.
+# The harmonization reference set: the panel's variants, minus the entries
+# whose id does not encode its alleles (e.g. R5 INS/DEL tags). Their A1/A2
+# columns may be correct, but the summary statistics carry no way to say which
+# orientation was measured at that position, so a GWAS variant there must be
+# dropped rather than aligned by a guess that could sign-flip a real signal --
+# the same "exclude what you can't interpret" rule the RAISS flip-pair /
+# flip-of-known masks apply. Removing the reference row leaves the GWAS variant
+# unmatched, so removeUnmatched removes it.
+#
+# Filtered HERE rather than inside .refVariantsFromSketch because the RAISS
+# path indexes into that frame and would misalign against its dosage if it
+# were filtered globally.
+# @noRd
+.sketchRefVariants <- function(ldSketch) {
+    filter(
+        .refVariantsFromSketch(ldSketch),
+        .ldSketchIdUsable(.data$variant_id)
+    )
+}
+
 .matchAgainstSketch <- function(
     df,
     ldSketch,
@@ -3164,21 +3184,7 @@ krigingOutlierQc <- function(
     removeStrandAmbiguous = TRUE,
     removeDups = TRUE
 ) {
-    refVariants <- .refVariantsFromSketch(ldSketch)
-    # Drop panel entries whose id does not encode its alleles (e.g. R5 INS/DEL
-    # tags). Their A1/A2 columns may be correct, but the summary statistics carry
-    # no way to say which orientation was measured at that position, so a GWAS
-    # variant there must be dropped rather than aligned by a guess that could
-    # sign-flip a real signal -- the same "exclude what you can't interpret" rule
-    # the RAISS flip-pair / flip-of-known masks apply. Removing the reference row
-    # leaves the GWAS variant unmatched, so removeUnmatched removes it. Filtered
-    # HERE (harmonization's own ref set) rather than in .refVariantsFromSketch,
-    # because the RAISS path indexes into that frame and would misalign against
-    # its dosage if it were filtered globally.
-    refVariants <- refVariants[
-        .ldSketchIdUsable(refVariants$variant_id), ,
-        drop = FALSE
-    ]
+    refVariants <- .sketchRefVariants(ldSketch)
     flipCandidates <- c("Z", "BETA")
     colToFlip <- intersect(flipCandidates, colnames(df))
     if (length(colToFlip) == 0L) {

--- a/R/sumstatsQc.R
+++ b/R/sumstatsQc.R
@@ -1722,7 +1722,12 @@ autoDecision <- function(df, highCorrCols) {
 # correspondence between `knownZscores$z` and the LD rows indexed by `knowns`.
 # @noRd
 .raissUnsafeToImpute <- function(refPanelIds, knownIds) {
-    .raissFlipPairMask(refPanelIds) |
+    # unusable-id: the id does not encode its alleles (e.g. an R5 INS/DEL tag).
+    # It is dropped from harmonization for the same reason -- the sumstats cannot
+    # say which orientation was measured -- so imputing it would put back a
+    # variant the drop exists to exclude.
+    !.ldSketchIdUsable(refPanelIds) |
+        .raissFlipPairMask(refPanelIds) |
         .raissFlipOfKnownMask(refPanelIds, knownIds)
 }
 
@@ -3160,6 +3165,20 @@ krigingOutlierQc <- function(
     removeDups = TRUE
 ) {
     refVariants <- .refVariantsFromSketch(ldSketch)
+    # Drop panel entries whose id does not encode its alleles (e.g. R5 INS/DEL
+    # tags). Their A1/A2 columns may be correct, but the summary statistics carry
+    # no way to say which orientation was measured at that position, so a GWAS
+    # variant there must be dropped rather than aligned by a guess that could
+    # sign-flip a real signal -- the same "exclude what you can't interpret" rule
+    # the RAISS flip-pair / flip-of-known masks apply. Removing the reference row
+    # leaves the GWAS variant unmatched, so removeUnmatched removes it. Filtered
+    # HERE (harmonization's own ref set) rather than in .refVariantsFromSketch,
+    # because the RAISS path indexes into that frame and would misalign against
+    # its dosage if it were filtered globally.
+    refVariants <- refVariants[
+        .ldSketchIdUsable(refVariants$variant_id), ,
+        drop = FALSE
+    ]
     flipCandidates <- c("Z", "BETA")
     colToFlip <- intersect(flipCandidates, colnames(df))
     if (length(colToFlip) == 0L) {

--- a/R/variantId.R
+++ b/R/variantId.R
@@ -98,6 +98,35 @@ isSnpAlleles <- function(a1, a2) {
     replace_na(isSnp, FALSE)
 }
 
+#' Test whether variant ids encode usable DNA alleles (not a tag like INS/DEL).
+#'
+#' Some LD panels (e.g. ADSP R5) name a variant with a tag where an allele belongs
+#' -- \code{chr21:13988152:INS:T} whose real alleles are \code{A}/\code{AT} -- so the
+#' id no longer encodes its alleles, even though the panel's A1/A2 columns are correct.
+#' The id-string matchers (\code{.ldFromSketchMatch}, \code{.subsetSketchToIds}) key on
+#' the id and cannot interpret such a record. Returns TRUE only where both parsed
+#' alleles are pure DNA; tests for DNA rather than the literal \code{INS}/\code{DEL},
+#' so any tagging convention is caught. A legitimate multi-base indel allele (e.g.
+#' \code{TAATGG}) stays usable.
+#' An id that does not parse to \code{chr:pos:allele:allele} at all -- e.g. an
+#' rsID -- is a different, valid convention (its A1/A2 columns are clean and
+#' \code{matchVariants} handles it by string), so it is NOT flagged; only an id
+#' that parses to the allele form but whose allele slot holds a non-DNA tag is
+#' unusable.
+#' @param ids Character vector of variant ids (\code{chr:pos:A2:A1}).
+#' @return Logical vector, TRUE unless the id parses to a non-DNA allele.
+#' @noRd
+.ldSketchIdUsable <- function(ids) {
+    p <- parseVariantId(ids)
+    parsed <- !is.na(p$A1) & !is.na(p$A2)
+    dnaOk <- replace_na(
+        str_detect(p$A1, "^[ACGT]+$") & str_detect(p$A2, "^[ACGT]+$"),
+        FALSE
+    )
+    # usable = not an allele-encoded id (rsID etc.) OR parsed and pure DNA.
+    !parsed | dnaOk
+}
+
 # Backwards-compat alias
 
 #' Detect the naming convention of variant IDs

--- a/tests/testthat/test_sumstatsQc.R
+++ b/tests/testthat/test_sumstatsQc.R
@@ -3249,6 +3249,49 @@ test_that("summaryStatsQc: harmonization re-keys SNP to the panel id and sign-fl
     expect_equal(z, c(1.0, -2.0, 1.5)) # only the swapped variant's Z flips
 })
 
+# ---------------------------------------------------------------------------
+# Uninterpretable panel ids (e.g. ADSP R5 INS/DEL tags): drop, don't guess
+# ---------------------------------------------------------------------------
+
+test_that(".ldSketchIdUsable flags tag-allele ids but not SNPs, real indels, or rsIDs", {
+    ids <- c("chr21:13988031:T:C", "chr1:788757:T:TAATGG", "chr21:16298:C:T",
+             "chr21:13988152:INS:T", "chr21:13988153:DEL:T", "rs12345", NA)
+    expect_equal(
+        pecotmr:::.ldSketchIdUsable(ids),
+        c(TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, TRUE)
+    )
+})
+
+test_that(".raissUnsafeToImpute now excludes tag-allele ids (third clause)", {
+    # A tag id has no flip twin, so it slipped through before; it must now be
+    # unsafe, while a normal SNP stays safe and the flip-pair behaviour is intact.
+    expect_true(pecotmr:::.raissUnsafeToImpute("chr21:13988152:INS:T", character(0)))
+    expect_false(pecotmr:::.raissUnsafeToImpute("chr21:16298:C:T", character(0)))
+    # flip-pair still flagged (both orientations present)
+    fp <- c("chr1:100:A:G", "chr1:100:G:A")
+    expect_true(all(pecotmr:::.raissUnsafeToImpute(fp, character(0))))
+})
+
+test_that("harmonization drops a variant on a tag-named panel position, keeps normal ones", {
+    skip_if_not_installed("pgenlibr")
+    h <- .ssQ_makeHandleVid() # ids chr1:100:G:A .. chr1:800:G:A, A1=A A2=G
+    df <- tibble(
+        chrom = c("1", "1"), pos = c(100L, 200L),
+        SNP = c("chr1:100:G:A", "chr1:200:G:A"),
+        A1 = c("A", "A"), A2 = c("G", "G"),
+        Z = c(1.0, 2.0), N = c(1000L, 1000L)
+    )
+    # control: both variants match the panel and survive
+    out0 <- pecotmr:::.matchAgainstSketch(df, h, matchMinProp = 0)
+    expect_setequal(pecotmr:::parseVariantId(out0$SNP)$pos, c(100L, 200L))
+    # tag the pos-200 panel id (A1/A2 columns stay the real alleles)
+    h@snpInfo$SNP[h@snpInfo$BP == 200L] <- "chr1:200:INS:A"
+    outT <- pecotmr:::.matchAgainstSketch(df, h, matchMinProp = 0)
+    # pos-200 is dropped (its only reference entry is uninterpretable); pos-100 kept
+    expect_true(100L %in% pecotmr:::parseVariantId(outT$SNP)$pos)
+    expect_false(200L %in% pecotmr:::parseVariantId(outT$SNP)$pos)
+})
+
 test_that("summaryStatsQc: slalom z-mismatch resolves sign-flipped variants against the panel", {
     # Pre-fix regression: a sign-flipped variant kept its input-orientation SNP,
     # which is absent from the panel, so .applyLdMismatchQcToEntry errored with

--- a/tests/testthat/test_sumstatsQc.R
+++ b/tests/testthat/test_sumstatsQc.R
@@ -3254,8 +3254,15 @@ test_that("summaryStatsQc: harmonization re-keys SNP to the panel id and sign-fl
 # ---------------------------------------------------------------------------
 
 test_that(".ldSketchIdUsable flags tag-allele ids but not SNPs, real indels, or rsIDs", {
-    ids <- c("chr21:13988031:T:C", "chr1:788757:T:TAATGG", "chr21:16298:C:T",
-             "chr21:13988152:INS:T", "chr21:13988153:DEL:T", "rs12345", NA)
+    ids <- c(
+        "chr21:13988031:T:C",
+        "chr1:788757:T:TAATGG",
+        "chr21:16298:C:T",
+        "chr21:13988152:INS:T",
+        "chr21:13988153:DEL:T",
+        "rs12345",
+        NA
+    )
     expect_equal(
         pecotmr:::.ldSketchIdUsable(ids),
         c(TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, TRUE)
@@ -3265,8 +3272,14 @@ test_that(".ldSketchIdUsable flags tag-allele ids but not SNPs, real indels, or 
 test_that(".raissUnsafeToImpute now excludes tag-allele ids (third clause)", {
     # A tag id has no flip twin, so it slipped through before; it must now be
     # unsafe, while a normal SNP stays safe and the flip-pair behaviour is intact.
-    expect_true(pecotmr:::.raissUnsafeToImpute("chr21:13988152:INS:T", character(0)))
-    expect_false(pecotmr:::.raissUnsafeToImpute("chr21:16298:C:T", character(0)))
+    expect_true(pecotmr:::.raissUnsafeToImpute(
+        "chr21:13988152:INS:T",
+        character(0)
+    ))
+    expect_false(pecotmr:::.raissUnsafeToImpute(
+        "chr21:16298:C:T",
+        character(0)
+    ))
     # flip-pair still flagged (both orientations present)
     fp <- c("chr1:100:A:G", "chr1:100:G:A")
     expect_true(all(pecotmr:::.raissUnsafeToImpute(fp, character(0))))
@@ -3276,10 +3289,13 @@ test_that("harmonization drops a variant on a tag-named panel position, keeps no
     skip_if_not_installed("pgenlibr")
     h <- .ssQ_makeHandleVid() # ids chr1:100:G:A .. chr1:800:G:A, A1=A A2=G
     df <- tibble(
-        chrom = c("1", "1"), pos = c(100L, 200L),
+        chrom = c("1", "1"),
+        pos = c(100L, 200L),
         SNP = c("chr1:100:G:A", "chr1:200:G:A"),
-        A1 = c("A", "A"), A2 = c("G", "G"),
-        Z = c(1.0, 2.0), N = c(1000L, 1000L)
+        A1 = c("A", "A"),
+        A2 = c("G", "G"),
+        Z = c(1.0, 2.0),
+        N = c(1000L, 1000L)
     )
     # control: both variants match the panel and survive
     out0 <- pecotmr:::.matchAgainstSketch(df, h, matchMinProp = 0)
@@ -6597,8 +6613,13 @@ test_that("raiss genotypeMatrix path: single-matrix, list, all-fail, and bad-typ
         n = rep(1000L, 5L),
         stringsAsFactors = FALSE
     )
-    list(imputed = list(resultFilter = impDf), knownZ = df["SNP"], df = df,
-         obs = obs, imp = imp)
+    list(
+        imputed = list(resultFilter = impDf),
+        knownZ = df["SNP"],
+        df = df,
+        obs = obs,
+        imp = imp
+    )
 }
 
 test_that(".qcRaissMerge preserves observed AF and leaves imputed AF NA", {


### PR DESCRIPTION
Some LD panels (ADSP R5) name ~3% of variants with a tag where an allele belongs — `chr21:13988152:INS:T` whose real alleles are `A`/`AT` — so the id no longer encodes its alleles even though the `A1`/`A2` columns are correct. Harmonisation keys on the allele columns and keeps the variant; the id-string LD lookup (`.ldFromSketchMatch`) then can't find it and aborts (`.fmLdFromSketch` / kriging prefilter: *N variant id(s) not present in the LD sketch panel*). R4 has none of these, so only R5 fails.

The panel's alleles are trustworthy but the summary statistics are not: at such a position the GWAS carries no way to say which orientation was measured, so aligning its z-score would be a guess that can sign-flip a real signal. **Dropping is the only choice that can't be wrong** — the same reasoning #576 already applies to flip-pairs.

- New `.ldSketchIdUsable` predicate: an id is usable unless it parses to a non-DNA allele (tests for DNA, not the literal `INS`/`DEL`; rsIDs and legitimate multi-base indel alleles stay usable).
- `.matchAgainstSketch` filters `.refVariantsFromSketch` by it, so a GWAS variant on such a position is dropped at harmonisation (`removeUnmatched`) — filtered at the call site, not in `.refVariantsFromSketch`, since the RAISS path indexes into that frame.
- `.raissUnsafeToImpute` gains it as a third clause. The id-string readers then never request the variant.

Validated on the real ADSP R5 chr21 panel: baseline reproduces the abort; the fix drops exactly the tag-position variants at QC and the run completes, through both direct calls and the real `gwas_sumstats_construct.R` + `fine_mapping.R` scripts. Suites pass with 0 unrelated changes; rsID panels unaffected.