### PR TITLE
Default fineMappingPipeline L to 10 and greedy-L off

### DIFF
--- a/R/fineMappingPipeline.R
+++ b/R/fineMappingPipeline.R
@@ -255,9 +255,10 @@
 #' @param keepVariants Character vector or \code{NULL}. Per-call override of the
 #'   \code{QtlDataset} variant allow-list; \code{NULL} uses the dataset's stored
 #'   value.
-#' @param L Integer. Maximum number of SuSiE single effects. Default \code{20}.
-#' @param Lgreedy Integer. Number of greedily-added effects in the SuSiE-inf
-#'   refinement. Default \code{5}.
+#' @param L Integer. Maximum number of SuSiE single effects. Default \code{10}.
+#' @param Lgreedy Integer or \code{NULL}. Number of greedily-added effects in the
+#'   SuSiE-inf refinement (the greedy-L loop). \code{NULL} (default) disables the
+#'   greedy loop and fits \code{L} directly.
 #' @param twasWeights Optional \code{\link{TwasWeights}} resume cache to reuse
 #'   previously fitted weights; \code{NULL} fits fresh.
 #' @param dataDrivenPriorWeightsCutoff Numeric or \code{NULL}. Cutoff below
@@ -458,7 +459,7 @@ setGeneric("fineMappingPipeline", function(data, ...) {
 # Mirrors the convention of .twasNormalizeMethods so the two pipelines
 # expose the same shape on the user side.
 # @noRd
-.fmNormalizeMethods <- function(methods, L = 20L, Lgreedy = 5L) {
+.fmNormalizeMethods <- function(methods, L = 10L, Lgreedy = NULL) {
     if (is.null(methods) || length(methods) == 0L) {
         msg <- glue(
             "fineMappingPipeline: `methods` must be a non-empty character ",
@@ -2594,8 +2595,8 @@ setMethod(
         jointRegions = FALSE,
         jointSpecification = NULL,
         addSusieInf = TRUE,
-        L = 20L,
-        Lgreedy = 5L,
+        L = 10L,
+        Lgreedy = NULL,
         coverage = 0.95,
         secondaryCoverage = c(0.7, 0.5),
         signalCutoff = 0.025,
@@ -3233,8 +3234,8 @@ setMethod(
         data,
         methods,
         addSusieInf = TRUE,
-        L = 20L,
-        Lgreedy = 5L,
+        L = 10L,
+        Lgreedy = NULL,
         coverage = 0.95,
         secondaryCoverage = c(0.7, 0.5),
         signalCutoff = 0.025,

--- a/tests/testthat/test_fineMappingPipeline.R
+++ b/tests/testthat/test_fineMappingPipeline.R
@@ -287,11 +287,11 @@ test_that(".fmNormalizeMethods: char-vector form deduplicates + seeds susie L de
     res <- pecotmr:::.fmNormalizeMethods(c("susie", "susie", "susieInf"))
     expect_equal(res$tokens, c("susie", "susieInf"))
     expect_equal(names(res$methodArgs), c("susie", "susieInf"))
-    # SuSiE-family tokens get the pipeline L / L_greedy defaults (pecotmr owns
-    # these, not the CLI wrappers).
-    expect_equal(res$methodArgs$susie$L, 20L)
-    expect_equal(res$methodArgs$susie$L_greedy, 5L)
-    expect_equal(res$methodArgs$susieInf$L, 20L)
+    # SuSiE-family tokens get the pipeline L default (pecotmr owns these, not the
+    # CLI wrappers). L_greedy defaults to NULL (greedy off), so it is left unset.
+    expect_equal(res$methodArgs$susie$L, 10L)
+    expect_null(res$methodArgs$susie$L_greedy)
+    expect_equal(res$methodArgs$susieInf$L, 10L)
     # Non-susie-family tokens are left untouched.
     expect_length(
         pecotmr:::.fmNormalizeMethods("mvsusie")$methodArgs$mvsusie,
@@ -306,8 +306,8 @@ test_that(".fmNormalizeMethods: named-list keeps kwargs + fills missing susie L"
     expect_equal(res$tokens, c("susie", "susieInf"))
     expect_equal(res$methodArgs$susie$L, 1) # explicit kwarg wins
     expect_false(res$methodArgs$susie$refine)
-    expect_equal(res$methodArgs$susie$L_greedy, 5L) # filled-in default
-    expect_equal(res$methodArgs$susieInf$L, 20L) # both filled
+    expect_null(res$methodArgs$susie$L_greedy) # greedy off by default (Lgreedy = NULL)
+    expect_equal(res$methodArgs$susieInf$L, 10L) # both filled
 })
 
 test_that(".fmNormalizeMethods: L / Lgreedy args override the susie defaults", {


### PR DESCRIPTION
fineMappingPipeline and .fmNormalizeMethods now default L to 10 (was 20) and Lgreedy to NULL (was 5), so the greedy-L loop is off unless a caller asks for it. Both stay overridable — pass L / Lgreedy, or a per-method L / L_greedy; passing Lgreedy = 5 reproduces the old default.

Updated the two tests that asserted the old filled-in defaults. The .twasMethodLookup path keeps its own L_greedy = 5 — separate code, out of scope.

Pairs with the RSS pipeline default change (xqtl-protocol #1422).